### PR TITLE
Add env example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Update the IP address values below to match your computer's local network IP
+GRAPHQL_URL=http://192.168.1.100:4000/graphql
+WS_URL=ws://192.168.1.100:4000/graphql
+YWS_URL=ws://192.168.1.100:4000/yws
+LSP_URL=ws://192.168.1.100:4000/lsp
+DEBUG_URL=ws://192.168.1.100:4000/debug

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 # Environment variables
 .env
 .env.*
+!.env.example
 
 # Expo
 .expo*

--- a/README.md
+++ b/README.md
@@ -20,8 +20,18 @@ A mobile IDE powered by GraphQL, Y.js, LSP & DAP, built within a professional mo
 # Copy the example environment file
 cp .env.example .env
 
-# IMPORTANT: Open .env and update the IP address (e.g., 192.168.1.100)
-# to match your computer's local network IP.
+# IMPORTANT: Open .env and update the IP address placeholders
+# (e.g., 192.168.1.100) to match your computer's local network IP.
 
 # Install all dependencies for all workspaces
 yarn install
+```
+
+### 2. Start the development servers
+```bash
+# Start the backend API
+yarn start:backend
+
+# In another terminal, start the mobile app
+yarn start:mobile
+```


### PR DESCRIPTION
## Summary
- close code block in README
- show how to start backend and mobile app
- add `.env.example` with placeholders
- track example env file in gitignore

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6871b57879448333860b6250f2061d0b

## Summary by Sourcery

Provide a sample environment file and improve README setup instructions

Documentation:
- Fix README code fence and clarify .env placeholder instructions
- Add commands to start the backend API and mobile app in the README

Chores:
- Add .env.example with placeholders and update .gitignore to exclude the real .env