### PR TITLE
Add AGENT instructions

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,10 @@
+# AGENT Instructions
+
+This repository contains a mobile IDE built with GraphQL, Y.js, and React Native. Contributions should follow these guidelines:
+
+- Install dependencies with `yarn install`.
+- Run the GraphQL code generator with `yarn codegen` if GraphQL schema or operations change.
+- Lint the code with `yarn lint` and run tests via `yarn test` before committing.
+- Build the backend with `yarn workspace backend build` when necessary.
+
+Commits should be concise and use the imperative mood. New code should be written in TypeScript.


### PR DESCRIPTION
## Summary
- add a new `AGENT.md` with contribution guidelines

## Testing
- `yarn lint` *(fails: lockfile missing)*
- `yarn test` *(fails: lockfile missing)*
- `yarn install` *(fails: react-native-monaco-editor not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871c3f989348333bb812bb20f7844cd

## Summary by Sourcery

Documentation:
- Add setup instructions, GraphQL code generation steps, linting and testing commands, backend build instructions, commit conventions, and TypeScript requirement in AGENT.md