### PR TITLE
Provide editor entry file

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -1,0 +1,3 @@
+import MonacoEditor, { MonacoEditorRef } from 'react-native-monaco-editor';
+export default MonacoEditor;
+export { MonacoEditorRef };


### PR DESCRIPTION
## Summary
- add a simple `src/index.tsx` in the `editor` package that re-exports `react-native-monaco-editor`

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6871b57e11808333a86cf6eddfe73306