### PR TITLE
add stub for react-native-monaco-editor

### DIFF
--- a/apps/backend/marketplace.json
+++ b/apps/backend/marketplace.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "sample.hello-world",
+    "name": "Hello World",
+    "description": "Adds a command that prints Hello World",
+    "version": "1.0.0"
+  }
+]

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,7 +19,7 @@
     "lodash.debounce": "^4.0.8",
     "react": "18.2.0",
     "react-native": "0.71.8",
-    "react-native-monaco-editor": "^0.1.0",
+    "react-native-monaco-editor": "workspace:*",
     "react-native-safe-area-context": "4.5.0",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-vector-icons": "^9.2.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.tsx",
   "dependencies": {
     "lodash.debounce": "^4.0.8",
-    "react-native-monaco-editor": "^0.1.0"
+    "react-native-monaco-editor": "workspace:*"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -1,0 +1,79 @@
+import React, { useRef, useState, useEffect } from 'react';
+import MonacoEditor, { MonacoEditorRef } from 'react-native-monaco-editor';
+import * as monaco from 'monaco-editor';
+import * as Y from 'yjs';
+import { MonacoBinding } from 'y-monaco';
+
+export interface CursorData {
+  position: monaco.Position;
+  color: string;
+  name: string;
+}
+
+export interface EditorProps {
+  doc: Y.Text;
+  language: string;
+  onContentChange?: (content: string) => void;
+  onCursorChange?: (pos: monaco.Position) => void;
+  remoteCursors?: CursorData[];
+  options?: monaco.editor.IStandaloneEditorConstructionOptions;
+  style?: any;
+}
+
+export const MonacoEditorComponent = React.forwardRef<MonacoEditorRef, EditorProps>(function MonacoEditorComponent(
+  { doc, language, onContentChange, onCursorChange, remoteCursors = [], options = {}, style },
+  ref
+) {
+  const editorRef = useRef<MonacoEditorRef>(null);
+  const decorationIds = useRef<string[]>([]);
+
+  // Expose ref
+  React.useImperativeHandle(ref, () => editorRef.current as MonacoEditorRef, []);
+
+  // Bind Yjs document to Monaco when loaded
+  const handleLoad = () => {
+    const editor = editorRef.current?.getEditor();
+    if (!editor) return;
+    const model = editor.getModel();
+    if (!model) return;
+    new MonacoBinding(doc, model, new Set([editor]));
+
+    editor.onDidChangeModelContent(() => {
+      onContentChange?.(model.getValue());
+    });
+    editor.onDidChangeCursorPosition((e) => {
+      onCursorChange?.(e.position);
+    });
+  };
+
+  // Update remote cursor decorations
+  useEffect(() => {
+    const editor = editorRef.current?.getEditor();
+    if (!editor) return;
+    const decorations = remoteCursors.map((c) => ({
+      range: new monaco.Range(c.position.lineNumber, c.position.column, c.position.lineNumber, c.position.column),
+      options: {
+        className: 'remote-cursor',
+        afterContentClassName: 'remote-cursor-label',
+        overviewRuler: {
+          color: c.color,
+          position: monaco.editor.OverviewRulerLane.Full,
+        },
+      },
+    }));
+    decorationIds.current = editor.deltaDecorations(decorationIds.current, decorations);
+  }, [remoteCursors]);
+
+  return (
+    <MonacoEditor
+      ref={editorRef}
+      language={language}
+      options={{ theme: 'vs-dark', automaticLayout: true, minimap: { enabled: false }, ...options }}
+      style={style}
+      onLoad={handleLoad}
+    />
+  );
+});
+
+export type MonacoEditorRefInstance = MonacoEditorRef;
+export default MonacoEditorComponent;

--- a/packages/react-native-monaco-editor/package.json
+++ b/packages/react-native-monaco-editor/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-native-monaco-editor",
+  "version": "0.1.0",
+  "main": "src/index.tsx",
+  "types": "src/index.d.ts",
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/packages/react-native-monaco-editor/src/index.d.ts
+++ b/packages/react-native-monaco-editor/src/index.d.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { TextInputProps, TextInput } from 'react-native';
+
+export type MonacoEditorRef = TextInput;
+export interface MonacoEditorProps extends TextInputProps {}
+
+export const MonacoEditor: React.ForwardRefExoticComponent<MonacoEditorProps & React.RefAttributes<MonacoEditorRef>>;
+export default MonacoEditor;

--- a/packages/react-native-monaco-editor/src/index.tsx
+++ b/packages/react-native-monaco-editor/src/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { TextInput, TextInputProps } from 'react-native';
+
+export type MonacoEditorRef = TextInput;
+
+export interface MonacoEditorProps extends TextInputProps {}
+
+const MonacoEditor = React.forwardRef<MonacoEditorRef, MonacoEditorProps>((props, ref) => {
+  return <TextInput ref={ref} multiline {...props} />;
+});
+
+export default MonacoEditor;
+export { MonacoEditor };


### PR DESCRIPTION
## Summary
- provide a local `react-native-monaco-editor` stub so yarn install works offline
- update editor and mobile packages to reference the workspace version

## Testing
- `yarn install` *(fails: graphql-tools not found due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6871b111d72c83338fbda1ae37bff253