### PR TITLE
Fix debounced save function

### DIFF
--- a/apps/mobile/src/screens/Editor.tsx
+++ b/apps/mobile/src/screens/Editor.tsx
@@ -13,9 +13,19 @@ export default function Editor({ route, navigation }) {
   const [remoteCursors, setRemoteCursors] = useState([]);
   const editorRef = React.useRef<MonacoEditorRef>(null);
 
-  const saveContent = debounce((content: string) => {
-    writeFile({ variables: { path, content } });
-  }, 1000);
+  const saveContent = React.useMemo(
+    () =>
+      debounce((content: string) => {
+        writeFile({ variables: { path, content } });
+      }, 1000),
+    [writeFile, path]
+  );
+
+  useEffect(() => {
+    return () => {
+      saveContent.cancel();
+    };
+  }, [saveContent]);
 
   useEffect(() => {
     navigation.setOptions({ title: path.split('/').pop() });


### PR DESCRIPTION
## Summary
- improve debounce logic in Editor screen so save handler persists across renders

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6871abd0833c8333a7807df1e1b405b7