### PR TITLE
Add stub for react-native-monaco-editor

### DIFF
--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -4,7 +4,8 @@
     "strict": true,
     "paths": {
       "shared/*": ["../../packages/shared/src/*"],
-      "packages/*": ["../../packages/*"]
+      "packages/*": ["../../packages/*"],
+      "react-native-monaco-editor": ["../../packages/react-native-monaco-editor/src"]
     }
   }
 }

--- a/packages/react-native-monaco-editor/package.json
+++ b/packages/react-native-monaco-editor/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "react-native-monaco-editor",
+  "version": "0.1.0",
+  "main": "src/index.tsx",
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/packages/react-native-monaco-editor/src/index.tsx
+++ b/packages/react-native-monaco-editor/src/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export type MonacoEditorRef = {
+  focus: () => void;
+  revealLineInCenter: (lineNumber: number) => void;
+};
+
+export interface MonacoEditorProps {
+  value?: string;
+  language?: string;
+  onChangeText?: (value: string) => void;
+  style?: object;
+}
+
+const MonacoEditor = React.forwardRef<MonacoEditorRef, MonacoEditorProps>(
+  function MonacoEditor(_props, ref) {
+    React.useImperativeHandle(ref, () => ({
+      focus: () => {},
+      revealLineInCenter: () => {},
+    }));
+    return <View />;
+  }
+);
+
+export default MonacoEditor;
+export { MonacoEditorRef, MonacoEditorProps };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,10 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "outDir": "dist"
+    "outDir": "dist",
+    "paths": {
+      "react-native-monaco-editor": ["./packages/react-native-monaco-editor/src"]
+    }
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
### **User description**
## Summary
- create a local `react-native-monaco-editor` package as a simple stub
- map the new package in tsconfig files

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6871d5d62da083338b347110b0a596e6


___

### **PR Type**
Enhancement


___

### **Description**
- Create local stub package for `react-native-monaco-editor`

- Add TypeScript path mappings for package resolution

- Implement basic Monaco editor interface with React Native


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Create Package"] --> B["Add TypeScript Mappings"]
  B --> C["Implement Stub Interface"]
  C --> D["Configure Path Resolution"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Create package configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-native-monaco-editor/package.json

<li>Create new package configuration with React Native dependencies<br> <li> Set main entry point to <code>src/index.tsx</code>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/9/files#diff-3ebeac57295ecdddbdbc5d403af3b2d745578d91823d0d7e3c0a30ac2a9edf30">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tsconfig.json</strong><dd><code>Configure mobile app TypeScript paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/mobile/tsconfig.json

- Add path mapping for `react-native-monaco-editor` package


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/9/files#diff-c9d35250a4638a176367da0fb5bb76d750d1a234b8a54b692970d11fdad8de3f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tsconfig.base.json</strong><dd><code>Configure base TypeScript paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tsconfig.base.json

- Add base TypeScript path configuration for package resolution


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/9/files#diff-0b280a445be167f54cd916c0718c952b8e0d4ca9621903d05eec25efd4c6ed6d">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Implement Monaco editor stub component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-native-monaco-editor/src/index.tsx

<li>Implement stub Monaco editor component with React forwardRef<br> <li> Define TypeScript interfaces for props and ref methods<br> <li> Add empty implementations for focus and line reveal methods


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/9/files#diff-826ecc9bc36cfc7acc65c097820c31be0fe3cbe2310d923d246a1e735ebbce1e">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>