### PR TITLE
Resolve LICENSE year conflict

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 MobileVSCode
+Copyright (c) 2024 MobileVSCode Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update copyright year in `LICENSE`

## Testing
- `yarn install` *(fails: graphql-tools@^8.7.0: No candidates found)*
- `yarn lint` *(fails: package missing from lockfile)*
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6871de79c9f08333a4ba2cf7a9ef1d2e

## Summary by Sourcery

Chores:
- Bump the copyright year in LICENSE to 2024