### PR TITLE
Add VSIX packaging

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -1,0 +1,35 @@
+name: Build VSIX
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Extension
+        run: yarn workspace mobile-vscode-server build
+
+      - name: Install vsce
+        run: yarn global add vsce
+
+      - name: Package VSIX
+        run: vsce package --out mobile-vscode-server.vsix
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: vscode-extension
+          path: mobile-vscode-server.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
       - name: Lint code
         run: yarn lint
       - name: Build backend
-        run: yarn workspace backend build
+        run: yarn workspace mobile-vscode-server build
 
   test:
     runs-on: ubuntu-latest
     needs: lint-and-build
     strategy:
       matrix:
-        workspace: ['backend', 'shared']
+        workspace: ['mobile-vscode-server', 'shared']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/AGENT.md
+++ b/AGENT.md
@@ -5,6 +5,6 @@ This repository contains a mobile IDE built with GraphQL, Y.js, and React Native
 - Install dependencies with `yarn install`.
 - Run the GraphQL code generator with `yarn codegen` if GraphQL schema or operations change.
 - Lint the code with `yarn lint` and run tests via `yarn test` before committing.
-- Build the backend with `yarn workspace backend build` when necessary.
+- Build the backend with `yarn workspace mobile-vscode-server build` when necessary.
 
 Commits should be concise and use the imperative mood. New code should be written in TypeScript.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ yarn start:backend
 yarn start:mobile
 ```
 
+### 4. Package the VS Code extension
+```bash
+python3 scripts/build_vsix.py
+```
+
 ## 📄 License
 
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.

--- a/apps/backend/.vscodeignore
+++ b/apps/backend/.vscodeignore
@@ -1,0 +1,10 @@
+**/*.ts
+**/*.tsx
+**/*.map
+**/*.spec.*
+**/tsconfig.json
+.vscode/**
+.git/**
+README.md
+**/jest.config.js
+**/tests/**

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,11 +1,32 @@
 {
-  "name": "backend",
-  "version": "1.0.0",
+  "name": "mobile-vscode-server",
+  "displayName": "Mobile VSCode Server",
+  "publisher": "codex",
+  "version": "0.1.0",
+  "description": "Provides GraphQL, Git and Y.js back-end for mobile client",
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "categories": [
+    "Other"
+  ],
   "main": "dist/index.js",
+  "activationEvents": [
+    "onCommand:mobile-vscode-server.start"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "mobile-vscode-server.start",
+        "title": "Start Mobile VSCode Server"
+      }
+    ]
+  },
   "scripts": {
     "build": "tsc -b",
     "start": "node dist/index.js",
-    "test": "jest"
+    "test": "jest",
+    "vscode:prepublish": "yarn build"
   },
   "dependencies": {
     "apollo-server-express": "^3.10.4",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "codegen": "graphql-codegen --config codegen.yml",
     "lint": "eslint . --ext .ts,.tsx",
-    "build": "yarn workspace backend build",
-    "start:backend": "yarn workspace backend start",
+    "build": "yarn workspace mobile-vscode-server build",
+    "start:backend": "yarn workspace mobile-vscode-server start",
     "start:mobile": "yarn workspace mobile start",
     "test": "yarn workspaces run test"
   },

--- a/scripts/build_vsix.py
+++ b/scripts/build_vsix.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import subprocess
+from pathlib import Path
+
+
+def run(cmd):
+    print('> ' + ' '.join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    run(['yarn', 'install'])
+    run(['yarn', 'workspace', 'mobile-vscode-server', 'build'])
+    vsix = 'mobile-vscode-server.vsix'
+    run(['npx', 'vsce', 'package', '-o', vsix])
+    print(f'Packaged extension to {vsix}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- configure VS Code extension manifest in the backend package
- add `.vscodeignore` to slim down packaged files
- package VSIX in CI workflow
- add a local build helper script
- update README with packaging instructions
- update workspace scripts and guidelines for new backend package name

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test` *(fails: jest not found)*
- `yarn workspace mobile-vscode-server build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6871e5162774833388667fada99e3cce