### PR TITLE
Add VS Code extension packaging

### DIFF
--- a/.github/workflows/package-vsix.yml
+++ b/.github/workflows/package-vsix.yml
@@ -1,0 +1,29 @@
+name: Build VSIX
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build extension
+        run: yarn workspace extension run vscode:prepublish
+      - name: Install vsce
+        run: npm install -g vsce
+      - name: Package VSIX
+        run: vsce package --out mobile-vscode-server.vsix
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v3
+        with:
+          name: vscode-extension
+          path: mobile-vscode-server.vsix

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ yarn start:backend
 yarn start:mobile
 ```
 
+## Packaging the VS Code Extension
+
+Build and package the backend as a VS Code extension:
+
+```bash
+python3 build_vsix.py
+```
+
+The script installs dependencies, builds the backend and extension, and outputs
+`mobile-vscode-server.vsix` for installation or distribution.
+
 ## 📄 License
 
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.

--- a/build_vsix.py
+++ b/build_vsix.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import subprocess
+
+
+def run(cmd):
+    print('> ' + ' '.join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    run(['yarn', 'install'])
+    run(['yarn', 'codegen'])
+    run(['yarn', 'workspace', 'extension', 'run', 'vscode:prepublish'])
+    run(['npx', 'vsce', 'package', '-o', 'mobile-vscode-server.vsix'])
+
+
+if __name__ == '__main__':
+    main()

--- a/extension/.vscodeignore
+++ b/extension/.vscodeignore
@@ -1,0 +1,7 @@
+**/*.ts
+**/*.map
+**/tsconfig.json
+.vscode/**
+.git/**
+README.md
+LICENSE

--- a/extension/copyBackend.cjs
+++ b/extension/copyBackend.cjs
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+function copyRecursive(src, dest) {
+  if (!fs.existsSync(src)) return;
+  if (fs.statSync(src).isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      copyRecursive(path.join(src, entry), path.join(dest, entry));
+    }
+  } else {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  }
+}
+
+const backendDist = path.resolve(__dirname, '../apps/backend/dist');
+const destDir = path.resolve(__dirname, 'out/backend');
+copyRecursive(backendDist, destDir);

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,11 +1,27 @@
 {
-  "name": "backend",
-  "version": "1.0.0",
-  "main": "dist/index.js",
+  "name": "mobile-vscode-server",
+  "displayName": "Mobile VSCode Server",
+  "publisher": "mobilevs",
+  "version": "0.1.0",
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "categories": ["Other"],
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onCommand:mobile-vscode-server.start"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "mobile-vscode-server.start",
+        "title": "Start Mobile VSCode Server"
+      }
+    ]
+  },
   "scripts": {
-    "build": "tsc -b",
-    "start": "node dist/index.js",
-    "test": "jest"
+    "build": "tsc -p . && yarn workspace backend build && node ./copyBackend.cjs",
+    "vscode:prepublish": "npm run build"
   },
   "dependencies": {
     "apollo-server-express": "^3.10.4",
@@ -25,13 +41,6 @@
     "y-websocket": "^1.5.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.17",
-    "@types/jest": "^29.5.2",
-    "@types/jsonwebtoken": "^9.0.2",
-    "@types/lodash.debounce": "^4.0.7",
-    "@types/node": "^18.16.18",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.1.0",
     "typescript": "^5.1.3"
   }
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,0 +1,26 @@
+import * as vscode from 'vscode';
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+
+let serverProcess: ChildProcess | undefined;
+
+export function activate(context: vscode.ExtensionContext) {
+  const startCommand = vscode.commands.registerCommand('mobile-vscode-server.start', () => {
+    if (serverProcess) {
+      vscode.window.showInformationMessage('Mobile VSCode Server is already running.');
+      return;
+    }
+    const backendPath = context.asAbsolutePath(path.join('out', 'backend', 'index.js'));
+    serverProcess = spawn('node', [backendPath], { stdio: 'inherit' });
+    vscode.window.showInformationMessage('Mobile VSCode Server started.');
+  });
+
+  context.subscriptions.push(startCommand);
+}
+
+export function deactivate() {
+  if (serverProcess) {
+    serverProcess.kill();
+    serverProcess = undefined;
+  }
+}

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "outDir": "out"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "extension"
   ],
   "scripts": {
     "codegen": "graphql-codegen --config codegen.yml",
@@ -22,5 +23,5 @@
     "eslint": "^8.42.0",
     "typescript": "^5.1.3",
     "yarn": "^1.22.19"
-  }
+  },
 }


### PR DESCRIPTION
## Summary
- create `extension` package with VS Code extension manifest
- bundle backend build artifacts into the extension
- ignore development files with `.vscodeignore`
- add workflow to package the extension into a VSIX
- provide a helper `build_vsix.py` script
- document packaging steps in README
- update workspaces and backend dependencies

## Testing
- `yarn lint` *(fails: ESLint couldn't find a config)*
- `yarn test` *(fails: jest not found)*
- `yarn workspace backend build` *(fails: tsc missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6871e5162774833388667fada99e3cce