### PR TITLE
Improve search and editor state handling

### DIFF
--- a/apps/mobile/src/screens/Editor.tsx
+++ b/apps/mobile/src/screens/Editor.tsx
@@ -5,13 +5,15 @@ import { useYDoc } from '../hooks/useYDoc';
 import { useMutation } from '@apollo/client';
 import { WriteFileDocument } from 'shared/src/types';
 import debounce from 'lodash.debounce';
+import { useDocumentStore } from '../state/documentStore';
 
 export default function Editor({ route, navigation }) {
-  const { path, highlight } = route.params;
+  const { path } = route.params;
   const { ydoc, isLoading, awareness } = useYDoc(path);
   const [writeFile] = useMutation(WriteFileDocument);
   const [remoteCursors, setRemoteCursors] = useState([]);
   const editorRef = React.useRef<MonacoEditorRef>(null);
+  const consumeEditorAction = useDocumentStore(state => state.consumeEditorAction);
 
   const saveContent = React.useMemo(
     () =>
@@ -29,10 +31,11 @@ export default function Editor({ route, navigation }) {
 
   useEffect(() => {
     navigation.setOptions({ title: path.split('/').pop() });
-    if (highlight && editorRef.current) {
-        editorRef.current.revealLineInCenter(highlight, 0);
+    const action = consumeEditorAction();
+    if (action?.type === 'highlight-line' && editorRef.current) {
+      editorRef.current.revealLineInCenter(action.payload.line, 0);
     }
-  }, [path, highlight, navigation]);
+  }, [path, navigation, consumeEditorAction]);
 
   useEffect(() => {
     if (!awareness) return;

--- a/apps/mobile/src/screens/Search.tsx
+++ b/apps/mobile/src/screens/Search.tsx
@@ -1,11 +1,27 @@
-import React, { useState } from 'react';
-import { View, TextInput, Button, FlatList, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import React, { useState, useMemo } from 'react';
+import { View, TextInput, Button, SectionList, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
 import { useLazyQuery } from '@apollo/client';
-import { SearchDocument } from 'shared/src/types';
+import { SearchDocument, SearchQuery, SearchQueryVariables } from 'shared/src/types';
+import { useDocumentStore } from '../state/documentStore';
 
 export default function Search({ navigation }) {
   const [query, setQuery] = useState('');
-  const [fetchSearch, { data, loading }] = useLazyQuery(SearchDocument);
+  const [fetchSearch, { data, loading }] = useLazyQuery<SearchQuery, SearchQueryVariables>(SearchDocument);
+  const setEditorAction = useDocumentStore(state => state.setEditorAction);
+
+  const sections = useMemo(() => {
+    if (!data?.search) return [] as { title: string; data: SearchQuery['search'] }[];
+    const grouped = data.search.reduce<Record<string, SearchQuery['search']>>((acc, item) => {
+      (acc[item.file] = acc[item.file] || []).push(item);
+      return acc;
+    }, {});
+    return Object.entries(grouped).map(([file, items]) => ({ title: file, data: items }));
+  }, [data]);
+
+  const handlePress = (item: SearchQuery['search'][0]) => {
+    setEditorAction({ type: 'highlight-line', payload: { line: item.line } });
+    navigation.navigate('Explorer', { screen: 'Editor', params: { path: item.file } });
+  };
 
   return (
     <View style={styles.container}>
@@ -19,15 +35,16 @@ export default function Search({ navigation }) {
       />
       <Button title="Search" onPress={() => fetchSearch({ variables: { query } })} disabled={loading || !query} />
       {loading && <ActivityIndicator />}
-      <FlatList
-        data={data?.search}
-        keyExtractor={(item, i) => `${item.file}:${item.line}:${i}`}
+      <SectionList
+        sections={sections}
+        keyExtractor={(item, index) => `${item.file}:${item.line}:${index}`}
+        renderSectionHeader={({ section: { title } }) => (
+          <Text style={styles.section}>{title}</Text>
+        )}
         renderItem={({ item }) => (
-          <TouchableOpacity style={styles.result}
-            onPress={()=> navigation.navigate('Explorer', { screen: 'Editor', params: { path: item.file, highlight: item.line } })}
-          >
-            <Text style={styles.path}>{item.file}:{item.line}</Text>
-            <Text numberOfLines={1}>{item.text}</Text>
+          <TouchableOpacity style={styles.result} onPress={() => handlePress(item)}>
+            <Text style={styles.lineNumber}>{item.line}:</Text>
+            <Text style={styles.lineText} numberOfLines={1}>{item.text}</Text>
           </TouchableOpacity>
         )}
       />
@@ -37,6 +54,8 @@ export default function Search({ navigation }) {
 const styles = StyleSheet.create({
     container: { flex: 1, padding: 16, gap: 8 },
     input: { borderWidth: 1, borderColor: '#ccc', padding: 8, borderRadius: 4 },
-    result: { paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: '#eee' },
-    path: { color: 'gray', fontSize: 12 }
+    section: { paddingVertical: 4, backgroundColor: '#f0f0f0', fontWeight: 'bold' },
+    result: { flexDirection: 'row', paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: '#eee' },
+    lineNumber: { width: 40, textAlign: 'right', marginRight: 8, color: '#888', fontFamily: 'monospace' },
+    lineText: { flex: 1, fontFamily: 'monospace' },
 });

--- a/apps/mobile/src/state/documentStore.ts
+++ b/apps/mobile/src/state/documentStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+export interface EditorAction {
+  type: 'highlight-line';
+  payload: { line: number };
+}
+
+interface DocumentState {
+  editorAction: EditorAction | null;
+  setEditorAction: (action: EditorAction | null) => void;
+  consumeEditorAction: () => EditorAction | null;
+}
+
+export const useDocumentStore = create<DocumentState>((set, get) => ({
+  editorAction: null,
+  setEditorAction: action => set({ editorAction: action }),
+  consumeEditorAction: () => {
+    const action = get().editorAction;
+    if (action) {
+      set({ editorAction: null });
+    }
+    return action;
+  },
+}));


### PR DESCRIPTION
## Summary
- support highlighting lines using document store
- group search results by file
- show highlighted line in editor when navigating from search

## Testing
- `yarn install` *(fails: No candidates found for graphql-tools)*
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6871ea9a4ce08333a41c83b88911ffc2

## Summary by Sourcery

Enable grouping of search results by file and highlight specified lines in the editor through a shared document store

New Features:
- Group search results by file in a sectioned list
- Highlight and navigate to the selected line in the editor after a search

Enhancements:
- Switch from FlatList to SectionList with updated TypeScript query typings and improved result layout

Chores:
- Add a Zustand-based document store for coordinating editor highlight actions