### PR TITLE
Fix README merge leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ A mobile IDE powered by GraphQL, Y.js, LSP & DAP, built within a professional mo
 ```bash
 # Copy the example environment file
 cp .env.example .env
-
-# IMPORTANT: Open .env and update the IP address placeholders
-# (e.g., 192.168.1.100) to match your computer's local network IP.
-
+# Open `.env` and replace the IP address placeholders with your
+# computer's local network IP (for example, 192.168.1.100).
 # Install all dependencies for all workspaces
 yarn install
 ```


### PR DESCRIPTION
## Summary
- clarify how to update the `.env` file during setup

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6871fd772aa48333a0e2eb3dda43465a

## Summary by Sourcery

Documentation:
- Consolidate and clarify the instruction to open `.env` and replace IP address placeholders with the local network IP