### PR TITLE
Fix README license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,6 @@ python3 scripts/build_vsix.py
 
 ## 📄 License
 
-This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.
+This project is licensed under the MIT License.
+See the [LICENSE](./LICENSE) file for details.
+


### PR DESCRIPTION
## Summary
- clarify the README's license section wording

## Testing
- `yarn lint` *(fails: couldn't find ESLint config)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871fd772aa48333a0e2eb3dda43465a