### PR TITLE
Fix plugin generics

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -35,8 +35,8 @@ export interface PluginContext<IM extends IntentMap> {
 
 /** The bus your plugin uses to emit & listen */
 export interface PluginBus<
-  CTX extends PluginContext<IM>,
-  IM extends IntentMap
+  IM extends IntentMap,
+  CTX extends PluginContext<IM>
 > {
   emit<K extends keyof IM>(intent: K, payload: IM[K]): void
   on<K extends keyof IM>(intent: K, cb: (payload: IM[K]) => void): void
@@ -44,8 +44,8 @@ export interface PluginBus<
 
 /** The core Plugin interface */
 export interface Plugin<
-  CTX extends PluginContext<IM>,
-  IM extends IntentMap
+  IM extends IntentMap,
+  CTX extends PluginContext<IM>
 > {
   /** Called once when your plugin is loaded */
   init(ctx: CTX): void

--- a/src/plugins/MyPlugin.ts
+++ b/src/plugins/MyPlugin.ts
@@ -16,11 +16,11 @@ export interface MyIntents extends IntentMap {
 /** Strongly‐typed context for your plugin */
 export interface MyContext extends PluginContext<MyIntents> {}
 
-export class MyPlugin implements Plugin<MyContext, MyIntents> {
+export class MyPlugin implements Plugin<MyIntents, MyContext> {
   public readonly id: string
 
   constructor(
-    private readonly bus: PluginBus<MyContext, MyIntents>,
+    private readonly bus: PluginBus<MyIntents, MyContext>,
   ) {
     this.id = 'my-plugin'
   }
@@ -47,5 +47,5 @@ export class MyPlugin implements Plugin<MyContext, MyIntents> {
 }
 
 /** Export a factory so consumers get a real instance */
-export default (bus: PluginBus<MyContext, MyIntents>) =>
+export default (bus: PluginBus<MyIntents, MyContext>) =>
   new MyPlugin(bus)


### PR DESCRIPTION
## Summary
- reorder generic parameters for PluginBus and Plugin
- update MyPlugin example to match

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687230640260833381aada2c7918fc0a