### PR TITLE
Implement typed plugin scaffold

### DIFF
--- a/src/core/bus.ts
+++ b/src/core/bus.ts
@@ -1,0 +1,39 @@
+import { EventEmitter } from 'events'
+import {
+  PluginBus,
+  PluginContext,
+  IntentMap,
+  CRDTResult,
+} from './types'
+
+export class InMemoryBus<IM extends IntentMap>
+  implements PluginBus<IM, PluginContext<IM>>
+{
+  private readonly emitter = new EventEmitter()
+
+  emit<K extends keyof IM>(intent: K, payload: IM[K]): void {
+    this.emitter.emit(intent as string, payload)
+  }
+
+  on<K extends keyof IM>(intent: K, cb: (payload: IM[K]) => void): void {
+    this.emitter.on(intent as string, cb as (payload: unknown) => void)
+  }
+}
+
+export class BasicPluginContext<IM extends IntentMap>
+  implements PluginContext<IM>
+{
+  constructor(readonly id: string, private readonly bus: PluginBus<IM, PluginContext<IM>>) {}
+
+  on<K extends keyof IM>(
+    intent: K,
+    cb: (payload: IM[K]) => CRDTResult | Promise<CRDTResult>,
+  ): void {
+    this.bus.on(intent, cb as (payload: IM[K]) => void)
+  }
+
+  intent<K extends keyof IM>(intent: K, payload: IM[K]): Promise<CRDTResult> {
+    this.bus.emit(intent, payload)
+    return Promise.resolve({ success: true })
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -35,8 +35,8 @@ export interface PluginContext<IM extends IntentMap> {
 
 /** The bus your plugin uses to emit & listen */
 export interface PluginBus<
-  CTX extends PluginContext<IM>,
-  IM extends IntentMap
+  IM extends IntentMap,
+  CTX extends PluginContext<IM>
 > {
   emit<K extends keyof IM>(intent: K, payload: IM[K]): void
   on<K extends keyof IM>(intent: K, cb: (payload: IM[K]) => void): void
@@ -44,8 +44,8 @@ export interface PluginBus<
 
 /** The core Plugin interface */
 export interface Plugin<
-  CTX extends PluginContext<IM>,
-  IM extends IntentMap
+  IM extends IntentMap,
+  CTX extends PluginContext<IM>
 > {
   /** Called once when your plugin is loaded */
   init(ctx: CTX): void

--- a/src/plugins/MyPlugin.ts
+++ b/src/plugins/MyPlugin.ts
@@ -16,11 +16,11 @@ export interface MyIntents extends IntentMap {
 /** Strongly‐typed context for your plugin */
 export interface MyContext extends PluginContext<MyIntents> {}
 
-export class MyPlugin implements Plugin<MyContext, MyIntents> {
+export class MyPlugin implements Plugin<MyIntents, MyContext> {
   public readonly id: string
 
   constructor(
-    private readonly bus: PluginBus<MyContext, MyIntents>,
+    private readonly bus: PluginBus<MyIntents, MyContext>,
   ) {
     this.id = 'my-plugin'
   }
@@ -47,5 +47,5 @@ export class MyPlugin implements Plugin<MyContext, MyIntents> {
 }
 
 /** Export a factory so consumers get a real instance */
-export default (bus: PluginBus<MyContext, MyIntents>) =>
+export default (bus: PluginBus<MyIntents, MyContext>) =>
   new MyPlugin(bus)


### PR DESCRIPTION
## Summary
- add in-memory plugin bus and basic context
- adjust generic ordering for plugin types
- update MyPlugin to use new generics

## Testing
- `yarn tsc --noEmit` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687230640260833381aada2c7918fc0a

## Summary by Sourcery

Implement typed plugin scaffold by adding in-memory bus and basic plugin context, reorder core generics, and update example plugin to use the new generic signatures.

New Features:
- Add InMemoryBus implementation for emitting and listening to intents
- Add BasicPluginContext implementation for plugin context management

Enhancements:
- Swap generic parameter ordering for PluginBus and Plugin interfaces to IM before CTX
- Update MyPlugin class and its factory export to match the new generic order