### PR TITLE
Improve LSP message typing

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -16,12 +16,14 @@ import resolvers from './resolvers';
 import { pubsub } from './pubsub';
 import { PORT, ROOT_DIR } from '../config';
 
-const IncomingMessage = z.object({
+const incomingMessageSchema = z.object({
   jsonrpc: z.literal('2.0'),
   method: z.string().min(1),
   params: z.unknown().optional(),
   id: z.union([z.number(), z.string(), z.null()]).optional(),
 });
+
+type IncomingMessage = z.infer<typeof incomingMessageSchema>;
 
 async function start() {
   const app = express();
@@ -58,22 +60,30 @@ async function start() {
     );
 
     ws.on('message', data => {
+      const raw = data.toString();
       try {
-        const raw = data.toString();
         const parsed = JSON.parse(raw);
-        const msg = IncomingMessage.parse(parsed);
+        const msg: IncomingMessage = incomingMessageSchema.parse(parsed);
         if (msg.id !== undefined) {
           connection.sendRequest(msg.method, msg.params);
         } else {
           connection.sendNotification(msg.method, msg.params);
         }
       } catch (err) {
-        if (err instanceof z.ZodError) {
-          console.error('Invalid message structure:', err.errors);
-        } else if (err instanceof SyntaxError) {
-          console.error('Malformed JSON:', err.message);
-        } else {
-          console.error('Unexpected error handling incoming message:', err);
+        console.error('Message processing failed:', err);
+        let errorResponse = { error: err instanceof Error ? err.message : 'Unknown error' };
+
+        try {
+          const parsedData = JSON.parse(raw);
+          if (parsedData && parsedData.id !== undefined) {
+            errorResponse = { id: parsedData.id, error: errorResponse.error };
+          }
+        } catch {
+          // Unable to parse, send generic error
+        }
+
+        if (ws.readyState === ws.OPEN) {
+          ws.send(JSON.stringify(errorResponse));
         }
       }
     });


### PR DESCRIPTION
### **User description**
## Summary
- strengthen LSP message parsing by introducing an explicit `IncomingMessage` type
- add structured error responses when parsing fails

## Testing
- `yarn lint` *(fails: couldn't find ESLint config)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c20508388333b89eb75efacae945


___

### **PR Type**
Enhancement


___

### **Description**
- Strengthen LSP message parsing with explicit `IncomingMessage` type

- Add structured error responses for parsing failures

- Improve error handling with proper WebSocket state checks


___

### **Changes diagram**

```mermaid
flowchart LR
  A["WebSocket Message"] --> B["JSON Parse"]
  B --> C["Schema Validation"]
  C --> D["LSP Connection"]
  C --> E["Error Response"]
  E --> F["WebSocket Send"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Enhanced LSP message validation and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/index.ts

<li>Rename <code>IncomingMessage</code> to <code>incomingMessageSchema</code> for clarity<br> <li> Add explicit <code>IncomingMessage</code> type using <code>z.infer</code><br> <li> Replace detailed error logging with structured error responses<br> <li> Add WebSocket state check before sending error responses


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/38/files#diff-9f9b2e661dbb7c922ab7db42bebcf7f1e1d07de29477a7c6265daaa2fa6dc5ea">+19/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>