### PR TITLE
Improve editor stubs and lint setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "ignorePatterns": ["dist/", "node_modules/"],
+  "env": {
+    "es2021": true,
+    "node": true,
+    "browser": true
+  }
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -71,7 +71,9 @@ async function start() {
         }
       } catch (err) {
         console.error('Message processing failed:', err);
-        let errorResponse = { error: err instanceof Error ? err.message : 'Unknown error' };
+        let errorResponse: { error: string; id?: string | number | null } = {
+          error: err instanceof Error ? err.message : 'Unknown error',
+        };
 
         try {
           const parsedData = JSON.parse(raw);
@@ -99,7 +101,7 @@ async function start() {
   apolloServer.applyMiddleware({ app, path: '/graphql' });
 
   httpServer.on('upgrade', (req, socket, head) => {
-    const { pathname } = new URL(req.url!, `http://${req.headers.host}`);
+    const { pathname } = new URL(req.url || '', `http://${req.headers.host}`);
     if (pathname === '/graphql') wsServer.handleUpgrade(req, socket, head, ws => wsServer.emit('connection', ws, req));
     else if (pathname === '/yws') yWsServer.handleUpgrade(req, socket, head, ws => yWsServer.emit('connection', ws, req));
     else if (pathname === '/lsp') lspWsServer.handleUpgrade(req, socket, head, ws => lspWsServer.emit('connection', ws, req));

--- a/apps/mobile/src/screens/Editor.tsx
+++ b/apps/mobile/src/screens/Editor.tsx
@@ -11,7 +11,12 @@ export default function Editor({ route, navigation }) {
   const { path } = route.params;
   const { ydoc, isLoading, awareness } = useYDoc(path);
   const [writeFile] = useMutation(WriteFileDocument);
-  const [remoteCursors, setRemoteCursors] = useState([]);
+  interface RemoteCursor {
+    position: any;
+    color: string;
+    name: string;
+  }
+  const [remoteCursors, setRemoteCursors] = useState<RemoteCursor[]>([]);
   const editorRef = React.useRef<MonacoEditorRef>(null);
   const consumeEditorAction = useDocumentStore(state => state.consumeEditorAction);
 

--- a/packages/react-native-monaco-editor/src/index.tsx
+++ b/packages/react-native-monaco-editor/src/index.tsx
@@ -16,8 +16,14 @@ export interface MonacoEditorProps {
 const MonacoEditor = React.forwardRef<MonacoEditorRef, MonacoEditorProps>(
   function MonacoEditor(_props, ref) {
     React.useImperativeHandle(ref, () => ({
-      focus: () => {},
-      revealLineInCenter: () => {},
+      focus: () => {
+        /* Stub implementation for native focus */
+        console.debug('MonacoEditor.focus called');
+      },
+      revealLineInCenter: (lineNumber: number) => {
+        /* Stub implementation for scrolling */
+        console.debug('MonacoEditor.revealLineInCenter called', lineNumber);
+      },
     }));
     return <View />;
   }

--- a/src/plugins/MyPlugin.ts
+++ b/src/plugins/MyPlugin.ts
@@ -14,7 +14,7 @@ export interface MyIntents extends IntentMap {
 }
 
 /** Strongly‐typed context for your plugin */
-export interface MyContext extends PluginContext<MyIntents> {}
+export type MyContext = PluginContext<MyIntents>;
 
 export class MyPlugin implements Plugin<MyIntents, MyContext> {
   public readonly id: string


### PR DESCRIPTION
## Summary
- add ESLint config and fix lint errors
- implement debug stubs for Monaco editor focus helpers
- update plugin type declaration
- improve backend WebSocket upgrade and error handling
- refine editor cursor typing

## Testing
- `yarn lint`
- `yarn workspace mobile-vscode-server test`
- `yarn workspace shared test`
- `yarn workspace mobile-vscode-server build`


------
https://chatgpt.com/codex/tasks/task_e_6872d74b7ca48333a1a63130b005d646