### PR TITLE
Add ESLint config and fix lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended'
+  ],
+  ignorePatterns: ['dist/', 'node_modules/'],
+};

--- a/apps/mobile/src/screens/Explorer.tsx
+++ b/apps/mobile/src/screens/Explorer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SectionList, Text, TouchableOpacity, View, ActivityIndicator, StyleSheet } from 'react-native';
+import { SectionList, Text, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useQuery } from '@apollo/client';
 import { ListDirectoryDocument } from 'shared/src/types';

--- a/packages/react-native-monaco-editor/src/index.tsx
+++ b/packages/react-native-monaco-editor/src/index.tsx
@@ -16,8 +16,12 @@ export interface MonacoEditorProps {
 const MonacoEditor = React.forwardRef<MonacoEditorRef, MonacoEditorProps>(
   function MonacoEditor(_props, ref) {
     React.useImperativeHandle(ref, () => ({
-      focus: () => {},
-      revealLineInCenter: () => {},
+      focus: () => {
+        console.warn('MonacoEditor focus is not implemented.');
+      },
+      revealLineInCenter: () => {
+        console.warn('MonacoEditor revealLineInCenter is not implemented.');
+      },
     }));
     return <View />;
   }

--- a/src/plugins/MyPlugin.ts
+++ b/src/plugins/MyPlugin.ts
@@ -14,7 +14,7 @@ export interface MyIntents extends IntentMap {
 }
 
 /** Strongly‐typed context for your plugin */
-export interface MyContext extends PluginContext<MyIntents> {}
+export type MyContext = PluginContext<MyIntents>;
 
 export class MyPlugin implements Plugin<MyIntents, MyContext> {
   public readonly id: string


### PR DESCRIPTION
## Summary
- configure ESLint
- fix stub methods in `react-native-monaco-editor`
- clean up unused import in Explorer screen
- remove empty interface in MyPlugin

## Testing
- `yarn lint`
- `yarn workspace mobile-vscode-server test`
- `yarn workspace shared test`


------
https://chatgpt.com/codex/tasks/task_e_6872d74b7ca48333a1a63130b005d646