### PR TITLE
Fix Editor language detection

### DIFF
--- a/apps/mobile/src/hooks/useYDoc.ts
+++ b/apps/mobile/src/hooks/useYDoc.ts
@@ -32,7 +32,7 @@ export function useYDoc(docId: string) {
     providerRef.current = provider;
 
     return () => {
-      provider.disconnect();
+      provider.destroy();
     };
   }, [docId, ydoc]);
 

--- a/apps/mobile/src/screens/Editor.tsx
+++ b/apps/mobile/src/screens/Editor.tsx
@@ -63,7 +63,10 @@ export default function Editor({ route, navigation }) {
       <EditorComponent
         ref={editorRef}
         doc={ydoc.getText('monaco')}
-        language={(path.split('.').pop())}
+        language={(() => {
+          const match = /\.([^.\/]+)$/.exec(path);
+          return match ? match[1] : 'plaintext';
+        })()}
         onContentChange={saveContent}
         onCursorChange={(position) => awareness?.setLocalStateField('cursor', position)}
         remoteCursors={remoteCursors}


### PR DESCRIPTION
## Summary
- improve Y.js provider cleanup
- improve language detection for the mobile editor

## Testing
- `yarn lint` *(fails: Could not find ESLint configuration)*
- `yarn test` *(fails: jest not found)*
- `yarn workspace mobile-vscode-server test`
- `yarn workspace shared test`


------
https://chatgpt.com/codex/tasks/task_e_6872d74b7ca48333a1a63130b005d646

## Summary by Sourcery

Enhance mobile editor to more robustly detect file language and improve Y.js provider cleanup

Enhancements:
- Use regex-based extension matching in mobile editor and default to plaintext when no extension is found
- Replace provider.disconnect with provider.destroy for proper Y.js provider teardown