### PR TITLE
Improve WebSocket parsing logic

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -61,8 +61,9 @@ async function start() {
 
     ws.on('message', data => {
       const raw = data.toString();
+      let parsed: any;
       try {
-        const parsed = JSON.parse(raw);
+        parsed = JSON.parse(raw);
         const msg: IncomingMessage = incomingMessageSchema.parse(parsed);
         if (msg.id !== undefined) {
           connection.sendRequest(msg.method, msg.params);
@@ -71,18 +72,10 @@ async function start() {
         }
       } catch (err) {
         console.error('Message processing failed:', err);
-        let parsedData: unknown;
-        try {
-          parsedData = JSON.parse(raw);
-        } catch {
-          // Ignore parse errors; respond with generic error
-        }
 
         const errorResponse: { error: string; id?: string | number | null } = {
           error: err instanceof Error ? err.message : 'Unknown error',
-          ...(parsedData && (parsedData as any).id !== undefined
-            ? { id: (parsedData as any).id }
-            : {}),
+          ...(parsed && parsed.id !== undefined ? { id: parsed.id } : {}),
         };
 
         if (ws.readyState === ws.OPEN) {

--- a/apps/mobile/src/screens/Editor.tsx
+++ b/apps/mobile/src/screens/Editor.tsx
@@ -64,7 +64,7 @@ export default function Editor({ route, navigation }) {
         ref={editorRef}
         doc={ydoc.getText('monaco')}
         language={(() => {
-          const match = /\.([^.\/]+)$/.exec(path);
+          const match = /\.([^./]+)$/.exec(path);
           return match ? match[1] : 'plaintext';
         })()}
         onContentChange={saveContent}


### PR DESCRIPTION
## Summary
- avoid repeated `JSON.parse` calls when handling LSP messages
- fix lint error in mobile editor file

## Testing
- `yarn lint`
- `yarn test` *(fails: jest not found)*
- `yarn workspace mobile-vscode-server test`
- `yarn workspace shared test`


------
https://chatgpt.com/codex/tasks/task_e_6873f7b96c0c83338a336bd030c4e5e9

## Summary by Sourcery

Improve WebSocket parsing logic to eliminate redundant JSON.parse calls and fix a lint error in the mobile editor file.

Bug Fixes:
- Fix lint error in mobile editor by correcting the filename regex

Enhancements:
- Consolidate JSON.parse calls in WebSocket message handler by caching the parsed object for both normal and error flows