### PR TITLE
Return all plugin bus results

### DIFF
--- a/packages/react-native-monaco-editor/src/editor-html.ts
+++ b/packages/react-native-monaco-editor/src/editor-html.ts
@@ -1,4 +1,13 @@
-export const editorHtml = (initialValue: string, language: string, yjsScript: string) => `
+/**
+ * Generate the HTML string used by the embedded editor.
+ * The optional `trustedScript` is inserted verbatim and must not contain
+ * untrusted user content.
+ */
+export const editorHtml = (
+  initialValue: string,
+  language: string,
+  trustedScript = ''
+) => `
 <!DOCTYPE html>
 <html>
 <head>
@@ -70,7 +79,7 @@ export const editorHtml = (initialValue: string, language: string, yjsScript: st
             window.editor = editor;
             window.monaco = monaco;
         });
-        ${yjsScript}
+        ${trustedScript}
     </script>
 </body>
 </html>

--- a/packages/react-native-monaco-editor/src/index.tsx
+++ b/packages/react-native-monaco-editor/src/index.tsx
@@ -24,15 +24,7 @@ const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
     const editorRef = useRef<any>(null);
 
     const initialText = useMemo(() => doc.toString().replace(/`/g, '\\`'), [doc]);
-    const htmlContent = useMemo(
-      () =>
-        editorHtml(
-          initialText,
-          language,
-          `\n          // Y.js and MonacoBinding setup will be injected here\n          // This creates a placeholder for the collaborative bindings\n        `
-        ),
-      [initialText, language]
-    );
+    const htmlContent = useMemo(() => editorHtml(initialText, language), [initialText, language]);
 
     useImperativeHandle(ref, () => ({
       revealLineInCenter: (lineNumber, scroll = 1) => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,13 +24,13 @@ export interface PluginContext<IM extends IntentMap> {
   ): void
 
   /**
-   * Fire an intent on the bus and get a CRDTResult back.
+   * Fire an intent on the bus and get all listener results back.
    * Return type can be specialized if you need.
    */
   intent<K extends keyof IM>(
     intent: K,
     payload: IM[K],
-  ): Promise<CRDTResult>
+  ): Promise<CRDTResult[]>
 }
 
 /** The bus your plugin uses to emit & listen */
@@ -38,8 +38,11 @@ export interface PluginBus<
   IM extends IntentMap,
   CTX extends PluginContext<IM>
 > {
-  emit<K extends keyof IM>(intent: K, payload: IM[K]): void
-  on<K extends keyof IM>(intent: K, cb: (payload: IM[K]) => void): void
+  emit<K extends keyof IM>(intent: K, payload: IM[K]): Promise<CRDTResult[]>
+  on<K extends keyof IM>(
+    intent: K,
+    cb: (payload: IM[K]) => CRDTResult | Promise<CRDTResult>,
+  ): void
 }
 
 /** The core Plugin interface */

--- a/src/plugins/MyPlugin.ts
+++ b/src/plugins/MyPlugin.ts
@@ -5,6 +5,7 @@ import {
   CRDTResult,
   IntentMap,
 } from '../core/types'
+import { randomUUID } from 'crypto'
 
 /** Define the intents your plugin cares about */
 export interface MyIntents extends IntentMap {
@@ -17,6 +18,7 @@ export interface MyIntents extends IntentMap {
 
 export class MyPlugin implements Plugin<MyIntents, PluginContext<MyIntents>> {
   public readonly id: string
+  private nodes = new Map<string, { name: string }>()
 
   constructor(
     private readonly bus: PluginBus<MyIntents, PluginContext<MyIntents>>,
@@ -33,15 +35,16 @@ export class MyPlugin implements Plugin<MyIntents, PluginContext<MyIntents>> {
   private handleCreateNode(
     payload: MyIntents['createNode'],
   ): CRDTResult {
-    // …your logic here
-    return { success: true }
+    const id = randomUUID()
+    this.nodes.set(id, { name: payload.name })
+    return { success: true, snapshot: new TextEncoder().encode(id) }
   }
 
   private handleDeleteNode(
     payload: MyIntents['deleteNode'],
   ): CRDTResult {
-    // …your logic here
-    return { success: true }
+    const removed = this.nodes.delete(payload.id)
+    return { success: removed }
   }
 }
 


### PR DESCRIPTION
## Summary
- return arrays of results from intents
- use `crypto.randomUUID()` for node IDs
- clarify trusted script usage for embedded editor

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_687466eea66c83339ab8ed3d9022480f