### PR TITLE
Add backend unit tests

### DIFF
--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src']
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -63,6 +63,7 @@
     "@types/vscode": "^1.60.0",
     "@types/ws": "^8.18.1",
     "jest": "^29.5.0",
+    "jest-util": "^30.0.2",
     "ts-jest": "^29.1.0",
     "typescript": "^5.1.3"
   }

--- a/apps/backend/src/core/server.test.ts
+++ b/apps/backend/src/core/server.test.ts
@@ -1,0 +1,104 @@
+import { startServer, stopServer } from './server';
+import * as vscode from 'vscode';
+import { ensureAuthContext } from './auth';
+import { initializeFileSystemWatcher, disposeFileSystemWatcher } from '../watchers/fileSystemWatcher';
+
+jest.mock('./auth');
+jest.mock('../watchers/fileSystemWatcher');
+
+const listen = jest.fn((port: number, cb: () => void) => cb());
+const close = jest.fn((cb: () => void) => cb());
+const on = jest.fn();
+
+jest.mock('https', () => ({
+    createServer: jest.fn(() => ({ listen, close, on }))
+}), { virtual: true });
+
+jest.mock('express', () => {
+    const use = jest.fn();
+    const json = jest.fn(() => 'json');
+    const expressMock: any = jest.fn(() => ({ use }));
+    expressMock.json = json;
+    return Object.assign(expressMock, { __mocks: { use, json, expressMock } });
+}, { virtual: true });
+const expressModule = jest.requireMock('express').__mocks;
+const use = expressModule.use as jest.Mock;
+const json = expressModule.json as jest.Mock;
+const expressMock = expressModule.expressMock as jest.Mock;
+
+const start = jest.fn(() => Promise.resolve());
+const applyMiddleware = jest.fn();
+const stop = jest.fn();
+class FakeApolloServer {
+    constructor() {}
+    start = start;
+    applyMiddleware = applyMiddleware;
+    stop = stop;
+}
+jest.mock('apollo-server-express', () => ({
+    ApolloServer: jest.fn(() => new FakeApolloServer()),
+    gql: (literals: any, ...placeholders: any[]) => literals.reduce((acc: string, lit: string, i: number) => acc + placeholders[i - 1] + lit)
+}), { virtual: true });
+
+jest.mock('@graphql-tools/schema', () => ({ makeExecutableSchema: jest.fn(() => 'schema') }), { virtual: true });
+
+const ws = { on: jest.fn(), handleUpgrade: jest.fn(), close: jest.fn() };
+jest.mock('ws', () => ({ WebSocketServer: jest.fn(() => ws) }), { virtual: true });
+
+jest.mock('graphql-ws/lib/use/ws', () => ({ useServer: jest.fn(() => ({ dispose: jest.fn() })) }), { virtual: true });
+
+jest.mock('y-websocket/bin/utils.js', () => ({ setupWSConnection: jest.fn(), setPersistence: jest.fn() }), { virtual: true });
+
+jest.mock('yjs', () => ({}), { virtual: true });
+jest.mock('lodash.debounce', () => () => undefined, { virtual: true });
+
+jest.mock('fs', () => ({
+    existsSync: jest.fn(() => true),
+    readFileSync: jest.fn(() => Buffer.from('data'))
+}), { virtual: true });
+
+jest.mock('../graphql/resolvers', () => ({ getResolvers: jest.fn(() => ({})) }), { virtual: true });
+
+jest.mock('../ui/statusBar', () => ({ updateStatusBar: jest.fn() }), { virtual: true });
+
+jest.mock('path', () => ({ join: (...parts: string[]) => parts.join('/') }), { virtual: true });
+
+jest.mock('vscode', () => ({
+    workspace: {
+        getConfiguration: jest.fn(() => ({ get: jest.fn(() => 4000) }))
+    },
+    window: {
+        showWarningMessage: jest.fn(),
+        showErrorMessage: jest.fn(),
+        showInformationMessage: jest.fn()
+    }
+}), { virtual: true });
+
+describe('server start/stop', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (ensureAuthContext as jest.Mock).mockResolvedValue({ jwtSecret: 'a', pairingToken: 'b', isPaired: false });
+    });
+
+    it('starts and stops server', async () => {
+        const context = { extensionPath: '/ext' } as vscode.ExtensionContext;
+        await startServer(context);
+        await Promise.resolve();
+        expect(expressMock).toHaveBeenCalled();
+        expect(start).toHaveBeenCalled();
+        expect(listen).toHaveBeenCalledWith(4000, expect.any(Function));
+        expect(initializeFileSystemWatcher).toHaveBeenCalled();
+        stopServer();
+        expect(close).toHaveBeenCalled();
+        expect(stop).toHaveBeenCalled();
+        expect(disposeFileSystemWatcher).toHaveBeenCalled();
+    });
+
+    it('warns when already running', async () => {
+        const context = { extensionPath: '/ext' } as vscode.ExtensionContext;
+        await startServer(context);
+        await Promise.resolve();
+        await startServer(context);
+        expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+    });
+});

--- a/apps/backend/src/graphql/resolvers.test.ts
+++ b/apps/backend/src/graphql/resolvers.test.ts
@@ -31,7 +31,7 @@ const readDirectory: jest.Mock = __mocks.readDirectory;
 const readFile: jest.Mock = __mocks.readFile;
 const writeFile: jest.Mock = __mocks.writeFile;
 const getWorkspaceFolder: jest.Mock = __mocks.getWorkspaceFolder;
-const workspaceFolder = __mocks.workspaceFolder;
+const {workspaceFolder} = __mocks;
 
 beforeEach(() => {
     (fs.realpathSync.native as jest.Mock).mockImplementation((p: string) => p);

--- a/apps/backend/src/graphql/resolvers.test.ts
+++ b/apps/backend/src/graphql/resolvers.test.ts
@@ -1,0 +1,66 @@
+import { getResolvers } from './resolvers';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+jest.mock('vscode', () => {
+    const readDirectory = jest.fn();
+    const readFile = jest.fn();
+    const writeFile = jest.fn();
+    const workspaceFolder = { name: 'test', uri: { fsPath: '/workspace/test', toString: () => 'file:///workspace/test' } };
+    const getWorkspaceFolder = jest.fn(() => workspaceFolder);
+    return {
+        workspace: {
+            workspaceFolders: [workspaceFolder],
+            getWorkspaceFolder,
+            fs: { readDirectory, readFile, writeFile },
+            asRelativePath: (uri: vscode.Uri) => uri.fsPath.replace('/workspace/test/', '')
+        },
+        Uri: {
+            parse: (s: string) => ({ fsPath: s.replace('file://',''), toString: () => s }),
+            file: (p: string) => ({ fsPath: p, toString: () => `file://${p}` })
+        },
+        FileType: { Directory: 2 },
+        __mocks: { readDirectory, readFile, writeFile, getWorkspaceFolder, workspaceFolder }
+    };
+}, { virtual: true });
+
+jest.mock('fs');
+
+const { __mocks } = jest.requireMock('vscode');
+const readDirectory: jest.Mock = __mocks.readDirectory;
+const readFile: jest.Mock = __mocks.readFile;
+const writeFile: jest.Mock = __mocks.writeFile;
+const getWorkspaceFolder: jest.Mock = __mocks.getWorkspaceFolder;
+const workspaceFolder = __mocks.workspaceFolder;
+
+beforeEach(() => {
+    (fs.realpathSync.native as jest.Mock).mockImplementation((p: string) => p);
+    readDirectory.mockResolvedValue([['file.txt', 0], ['folder', 2]]);
+    readFile.mockResolvedValue(Buffer.from('content'));
+    writeFile.mockResolvedValue(undefined);
+    getWorkspaceFolder.mockReturnValue(workspaceFolder);
+});
+
+test('lists workspaces', () => {
+    const resolvers = getResolvers();
+    expect(resolvers.Query.listWorkspaces()).toEqual([
+        { name: 'test', uri: 'file:///workspace/test' }
+    ]);
+});
+
+test('lists directory contents', async () => {
+    const resolvers = getResolvers();
+    const result = await resolvers.Query.listDirectory(undefined, { workspaceUri: 'file:///workspace/test', path: '' });
+    expect(readDirectory).toHaveBeenCalled();
+    expect(result).toEqual([
+        { name: 'file.txt', path: 'file.txt', isDirectory: false },
+        { name: 'folder', path: 'folder', isDirectory: true }
+    ]);
+});
+
+test('writes file', async () => {
+    const resolvers = getResolvers();
+    const ok = await resolvers.Mutation.writeFile(undefined, { workspaceUri: 'file:///workspace/test', path: 'new.txt', content: 'hello' });
+    expect(writeFile).toHaveBeenCalled();
+    expect(ok).toBe(true);
+});

--- a/apps/backend/src/types/test-shims.d.ts
+++ b/apps/backend/src/types/test-shims.d.ts
@@ -1,0 +1,13 @@
+declare module 'yjs' {
+    namespace Y {
+        interface Doc {
+            on: any;
+        }
+    }
+    const Y: any;
+    export = Y;
+}
+declare module 'lodash.debounce' {
+    const fn: any;
+    export default fn;
+}

--- a/apps/backend/src/watchers/fileSystemWatcher.test.ts
+++ b/apps/backend/src/watchers/fileSystemWatcher.test.ts
@@ -1,0 +1,75 @@
+import { initializeFileSystemWatcher, disposeFileSystemWatcher } from './fileSystemWatcher';
+import { pubsub } from '../graphql/pubsub';
+import * as vscode from 'vscode';
+
+type Callback = (uri: vscode.Uri) => void;
+
+const createFileSystemWatcher = jest.fn();
+const getWorkspaceFolder = jest.fn();
+const asRelativePath = jest.fn();
+
+let onCreate: Callback | undefined;
+let onChange: Callback | undefined;
+let onDelete: Callback | undefined;
+const dispose = jest.fn();
+
+jest.mock('vscode', () => ({
+    workspace: {
+        createFileSystemWatcher: (pattern: string) => createFileSystemWatcher(pattern),
+        getWorkspaceFolder: (uri: vscode.Uri) => getWorkspaceFolder(uri),
+        asRelativePath: (uri: vscode.Uri, _f?: boolean) => asRelativePath(uri),
+    },
+    Uri: {
+        file: (p: string) => ({ fsPath: p, toString: () => `file://${p}` })
+    },
+    FileType: { Directory: 2 }
+}), { virtual: true });
+
+jest.mock('../graphql/pubsub', () => ({
+    pubsub: { publish: jest.fn() }
+}));
+
+beforeEach(() => {
+    (pubsub.publish as jest.Mock).mockClear();
+    createFileSystemWatcher.mockImplementation(() => {
+        return {
+            onDidCreate: (cb: Callback) => { onCreate = cb; },
+            onDidChange: (cb: Callback) => { onChange = cb; },
+            onDidDelete: (cb: Callback) => { onDelete = cb; },
+            dispose
+        } as any;
+    });
+    getWorkspaceFolder.mockReturnValue({ uri: { fsPath: '/workspace/test' } });
+    asRelativePath.mockImplementation((uri: vscode.Uri) => uri.fsPath.replace('/workspace/test/', ''));
+    onCreate = undefined;
+    onChange = undefined;
+    onDelete = undefined;
+    dispose.mockClear();
+});
+
+it('publishes events for file changes', () => {
+    initializeFileSystemWatcher();
+    expect(createFileSystemWatcher).toHaveBeenCalledWith('**/*');
+    const uri = { fsPath: '/workspace/test/foo.txt' } as vscode.Uri;
+    onCreate!(uri);
+    onChange!(uri);
+    onDelete!(uri);
+    expect(pubsub.publish).toHaveBeenCalledTimes(3);
+    expect(pubsub.publish).toHaveBeenCalledWith('FS_EVENT', { fsEvent: { event: 'create', path: 'foo.txt' } });
+    expect(pubsub.publish).toHaveBeenCalledWith('FS_EVENT', { fsEvent: { event: 'change', path: 'foo.txt' } });
+    expect(pubsub.publish).toHaveBeenCalledWith('FS_EVENT', { fsEvent: { event: 'delete', path: 'foo.txt' } });
+});
+
+it('does not reinitialize watcher if already set', () => {
+    initializeFileSystemWatcher();
+    initializeFileSystemWatcher();
+    expect(createFileSystemWatcher).toHaveBeenCalledTimes(1);
+});
+
+it('disposes watcher', () => {
+    initializeFileSystemWatcher();
+    disposeFileSystemWatcher();
+    expect(dispose).toHaveBeenCalled();
+    // calling again should be safe
+    disposeFileSystemWatcher();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,6 +3052,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/pattern@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/pattern@npm:30.0.1"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-regex-util: "npm:30.0.1"
+  checksum: 10c0/32c5a7bfb6c591f004dac0ed36d645002ed168971e4c89bd915d1577031672870032594767557b855c5bc330aa1e39a2f54bf150d2ee88a7a0886e9cb65318bc
+  languageName: node
+  linkType: hard
+
 "@jest/reporters@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/reporters@npm:29.7.0"
@@ -3086,6 +3096,15 @@ __metadata:
     node-notifier:
       optional: true
   checksum: 10c0/a754402a799541c6e5aff2c8160562525e2a47e7d568f01ebfc4da66522de39cbb809bbb0a841c7052e4270d79214e70aec3c169e4eae42a03bc1a8a20cb9fa2
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/schemas@npm:30.0.1"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10c0/27977359edc4b33293af7c85c53de5014a87c29b9ab98b0a827fedfc6635abdb522aad8c3ff276080080911f519699b094bd6f4e151b43f0cc5856ccc83c04a7
   languageName: node
   linkType: hard
 
@@ -3153,6 +3172,21 @@ __metadata:
     slash: "npm:^3.0.0"
     write-file-atomic: "npm:^4.0.2"
   checksum: 10c0/7f4a7f73dcf45dfdf280c7aa283cbac7b6e5a904813c3a93ead7e55873761fc20d5c4f0191d2019004fac6f55f061c82eb3249c2901164ad80e362e7a7ede5a6
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/types@npm:30.0.1"
+  dependencies:
+    "@jest/pattern": "npm:30.0.1"
+    "@jest/schemas": "npm:30.0.1"
+    "@types/istanbul-lib-coverage": "npm:^2.0.6"
+    "@types/istanbul-reports": "npm:^3.0.4"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.33"
+    chalk: "npm:^4.1.2"
+  checksum: 10c0/407469331e74f9bb1ffd40202c3a8cece2fd07ba535adeb60557bdcee13713cf2f14cf78869ba7ef50a7e6fe0ed7cc97ec775056dd640fc0a332e8fbfaec1ee8
   languageName: node
   linkType: hard
 
@@ -3960,6 +3994,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinclair/typebox@npm:^0.34.0":
+  version: 0.34.37
+  resolution: "@sinclair/typebox@npm:0.34.37"
+  checksum: 10c0/22fff01853d8f35e8a1f0be004e91a0c3ced16f35b8d7e915392e91bf021190bcba45102cd148679c53440c4ed228b31d7a2635461ea5d089ef581f6254ecfb4
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^3.0.0":
   version: 3.0.1
   resolution: "@sinonjs/commons@npm:3.0.1"
@@ -4134,7 +4175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1, @types/istanbul-lib-coverage@npm:^2.0.6":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
   checksum: 10c0/3948088654f3eeb45363f1db158354fb013b362dba2a5c2c18c559484d5eb9f6fd85b23d66c0a7c2fcfab7308d0a585b14dadaca6cc8bf89ebfdc7f8f5102fb7
@@ -4150,7 +4191,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-reports@npm:^3.0.0":
+"@types/istanbul-reports@npm:^3.0.0, @types/istanbul-reports@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/istanbul-reports@npm:3.0.4"
   dependencies:
@@ -4402,7 +4443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.8":
+"@types/yargs@npm:^17.0.33, @types/yargs@npm:^17.0.8":
   version: 17.0.33
   resolution: "@types/yargs@npm:17.0.33"
   dependencies:
@@ -5946,6 +5987,13 @@ __metadata:
   version: 3.9.0
   resolution: "ci-info@npm:3.9.0"
   checksum: 10c0/6f0109e36e111684291d46123d491bc4e7b7a1934c3a20dea28cba89f1d4a03acd892f5f6a81ed3855c38647e285a150e3c9ba062e38943bef57fee6c1554c3a
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "ci-info@npm:4.3.0"
+  checksum: 10c0/60d3dfe95d75c01454ec1cfd5108617dd598a28a2a3e148bd7e1523c1c208b5f5a3007cafcbe293e6fd0a5a310cc32217c5dc54743eeabc0a2bec80072fc055c
   languageName: node
   linkType: hard
 
@@ -8447,7 +8495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -9916,6 +9964,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-regex-util@npm:30.0.1":
+  version: 30.0.1
+  resolution: "jest-regex-util@npm:30.0.1"
+  checksum: 10c0/f30c70524ebde2d1012afe5ffa5691d5d00f7d5ba9e43d588f6460ac6fe96f9e620f2f9b36a02d0d3e7e77bc8efb8b3450ae3b80ac53c8be5099e01bf54f6728
+  languageName: node
+  linkType: hard
+
 "jest-regex-util@npm:^27.0.6":
   version: 27.5.1
   resolution: "jest-regex-util@npm:27.5.1"
@@ -10079,6 +10134,20 @@ __metadata:
     graceful-fs: "npm:^4.2.9"
     picomatch: "npm:^2.2.3"
   checksum: 10c0/bc55a8f49fdbb8f51baf31d2a4f312fb66c9db1483b82f602c9c990e659cdd7ec529c8e916d5a89452ecbcfae4949b21b40a7a59d4ffc0cd813a973ab08c8150
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^30.0.2":
+  version: 30.0.2
+  resolution: "jest-util@npm:30.0.2"
+  dependencies:
+    "@jest/types": "npm:30.0.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^4.2.0"
+    graceful-fs: "npm:^4.2.11"
+    picomatch: "npm:^4.0.2"
+  checksum: 10c0/07de384790b8e5a5925fba5448fa1475790a5b52271fbf99958c18e468da1af940f8b45e330d87766576cf6c5d1f4f41ce51c976483a5079653d9fcdba8aac8e
   languageName: node
   linkType: hard
 
@@ -11927,6 +11996,7 @@ __metadata:
     graphql-subscriptions: "npm:^2.0.0"
     graphql-ws: "npm:^5.11.0"
     jest: "npm:^29.5.0"
+    jest-util: "npm:^30.0.2"
     jsonwebtoken: "npm:^9.0.0"
     simple-git: "npm:^3.19.0"
     ts-jest: "npm:^29.1.0"


### PR DESCRIPTION
### **User description**
## Summary
- add Jest config for the backend package
- mock VS Code APIs in tests for GraphQL resolvers
- test file system watcher behaviour
- verify server start and stop logic
- include jest-util as a dev dependency

## Testing
- `yarn lint` *(fails: 3 errors, 41 warnings)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6874853e356083339e12b28f01609809


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive Jest test suite for backend package

- Mock VS Code APIs for GraphQL resolvers testing

- Test file system watcher event publishing behavior

- Verify server start/stop lifecycle and duplicate handling


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Jest Config"] --> B["Mock VS Code APIs"]
  B --> C["Test GraphQL Resolvers"]
  B --> D["Test File System Watcher"]
  B --> E["Test Server Lifecycle"]
  C --> F["Workspace & File Operations"]
  D --> G["Event Publishing"]
  E --> H["Start/Stop Logic"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.test.ts</strong><dd><code>Server lifecycle and integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/core/server.test.ts

<li>Mock Express, Apollo Server, WebSocket, and VS Code dependencies<br> <li> Test server start/stop functionality with proper cleanup<br> <li> Verify duplicate server start warning behavior<br> <li> Test file system watcher initialization and disposal


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/73/files#diff-acca3f0b8233792a0d74ad5bfdd1f439d7ea6d3c8e845a5e928d6fed048da867">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resolvers.test.ts</strong><dd><code>GraphQL resolver unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/graphql/resolvers.test.ts

<li>Mock VS Code workspace and file system APIs<br> <li> Test workspace listing functionality<br> <li> Test directory content listing with file type detection<br> <li> Test file writing operations through GraphQL mutations


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/73/files#diff-75985c36a6008a8db9f03e502ac89850f117c22ab5c92aa87272efa4e2c5699b">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-shims.d.ts</strong><dd><code>Test type definitions and shims</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/types/test-shims.d.ts

<li>Add TypeScript declarations for Yjs library<br> <li> Add type definitions for lodash.debounce module


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/73/files#diff-e2a5d22d95b84c709a50d4754e2764c31a6a517a0c14b5f66b29507963b1c555">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fileSystemWatcher.test.ts</strong><dd><code>File system watcher event tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/watchers/fileSystemWatcher.test.ts

<li>Mock VS Code file system watcher creation and events<br> <li> Test file system event publishing to GraphQL subscriptions<br> <li> Test watcher initialization and disposal lifecycle<br> <li> Verify duplicate initialization prevention


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/73/files#diff-73f3f3e243cf6377ae316ec3fbe72488ac412032405898b63cab3097491d987d">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jest.config.js</strong><dd><code>Jest configuration setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/jest.config.js

<li>Configure Jest with TypeScript preset<br> <li> Set Node.js test environment<br> <li> Configure test root directory to src folder


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/73/files#diff-24915c5cfdc45b73717499ffd28b9e56c7a5d26dd083db92665aef26ba9e6f0a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Jest utility dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/package.json

- Add jest-util as development dependency


</details>


  </td>
  <td><a href="https://github.com/ales27pm/mobile-vscode-project/pull/73/files#diff-8d3b741039fe624dded05aa46e994d93ec459ac8d8a0cfc747f92ef447a9513a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>