### PR TITLE
Fix yjs Doc typings for tests

### DIFF
--- a/apps/backend/src/types/test-shims.d.ts
+++ b/apps/backend/src/types/test-shims.d.ts
@@ -2,6 +2,7 @@ declare module 'yjs' {
     namespace Y {
         interface Doc {
             on: any;
+            destroy: () => void;
         }
     }
     const Y: any;


### PR DESCRIPTION
## Summary
- add missing `destroy` method to the yjs Doc test shim

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68759727531c833385eaba427cfe03ba

## Summary by Sourcery

Bug Fixes:
- Add destroy method to yjs Doc shim interface