### PR TITLE
Add architecture overview

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,24 @@
+# Architecture
+
+This project exposes a full VS Code environment to mobile devices using a server-based model.
+The backend runs as a VS Code extension and communicates with a React Native client.
+
+## Components
+
+- **apps/backend** – VS Code extension acting as the server. It exposes GraphQL and Y.js endpoints over WebSockets.
+- **apps/mobile** – React Native application using a Monaco-based editor to connect to the server.
+- **packages/shared** – Shared GraphQL schema and generated types used by both the server and client.
+- **packages/editor** – Mobile-friendly wrapper around Monaco.
+
+## Communication
+
+The extension starts a local server with two WebSocket endpoints:
+
+1. `/graphql` – handles queries, mutations and file events via GraphQL subscriptions.
+2. `/yjs` – synchronizes document edits using the Y.js protocol for low-latency collaboration.
+
+The mobile app connects to these endpoints to mirror the local VS Code workspace, enabling file browsing, editing and real-time collaboration.
+
+## Rationale
+
+Documenting the architecture ensures contributors share the same mental model and helps prevent merge conflicts stemming from differing assumptions about how the project is structured.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 MobileVSCode bridges the gap between powerful mobile hardware and professional development workflows. It provides a fluid, intuitive client that connects directly to your existing, fully-configured Visual Studio Code environment, allowing you to browse files, edit code, run searches and use Git from anywhere.
 
+See [ARCHITECTURE.md](ARCHITECTURE.md) for a high-level overview of how the server and mobile client work together.
+
 ## Key Features
 
 - **True VS Code Backend**: Runs as a standard VS Code extension with full access to your workspace, terminals and settings.


### PR DESCRIPTION
## Summary
- add ARCHITECTURE.md to describe project structure
- link to the architecture document in README

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6875a06b786083339647544b2a3691da

## Summary by Sourcery

Add an architecture overview document and link it from the README to clarify project structure and communication patterns.

Documentation:
- Introduce ARCHITECTURE.md detailing the backend, mobile client, shared packages, communication endpoints, and rationale
- Update README.md to include a link to the new ARCHITECTURE.md