### PR TITLE
Resolve merge conflicts and refine editor

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,3 +2,43 @@ packageExtensions:
   jest-expo@*:
     peerDependencies:
       react-native: "*"
+      react: "*"
+      jest: "*"
+      "@babel/core": "*"
+  ts-jest@*:
+    dependencies:
+      jest-util: "^29.0.0"
+  "@expo/cli@*":
+    peerDependencies:
+      expo-modules-autolinking: "*"
+  "@graphql-tools/graphql-tag-pluck@*":
+    peerDependencies:
+      "@babel/core": "*"
+  "@typescript-eslint/utils@*":
+    peerDependencies:
+      typescript: "*"
+  "babel-preset-expo@*":
+    peerDependencies:
+      "@babel/core": "*"
+  "expo-asset@*":
+    peerDependencies:
+      expo: "*"
+  "react-native-codegen@*":
+    dependencies:
+      "@babel/preset-env": "*"
+      "@babel/core": "*"
+  "@graphql-tools/code-file-loader@*":
+    peerDependencies:
+      "@babel/core": "*"
+  "@graphql-tools/git-loader@*":
+    peerDependencies:
+      "@babel/core": "*"
+  "@graphql-tools/github-loader@*":
+    peerDependencies:
+      "@babel/core": "*"
+  "expo@*":
+    peerDependencies:
+      "@babel/core": "*"
+  "@graphql-codegen/cli@*":
+    dependencies:
+      "@babel/core": "^7.28.0"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,24 @@
+# Architecture
+
+This project exposes a full VS Code environment to mobile devices using a server-based model.
+The backend runs as a VS Code extension and communicates with a React Native client.
+
+## Components
+
+- **apps/backend** – VS Code extension acting as the server. It exposes GraphQL and Y.js endpoints over WebSockets.
+- **apps/mobile** – React Native application using a Monaco-based editor to connect to the server.
+- **packages/shared** – Shared GraphQL schema and generated types used by both the server and client.
+- **packages/editor** – Mobile-friendly wrapper around Monaco.
+
+## Communication
+
+The extension starts a local server with two WebSocket endpoints:
+
+1. `/graphql` – handles queries, mutations and file events via GraphQL subscriptions.
+2. `/yjs` – synchronizes document edits using the Y.js protocol for low-latency collaboration.
+
+The mobile app connects to these endpoints to mirror the local VS Code workspace, enabling file browsing, editing and real-time collaboration.
+
+## Rationale
+
+Documenting the architecture ensures contributors share the same mental model and helps prevent merge conflicts stemming from differing assumptions about how the project is structured.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 MobileVSCode bridges the gap between powerful mobile hardware and professional development workflows. It provides a fluid, intuitive client that connects directly to your existing, fully-configured Visual Studio Code environment, allowing you to browse files, edit code, run searches and use Git from anywhere.
 
+See [ARCHITECTURE.md](ARCHITECTURE.md) for a high-level overview of how the server and mobile client work together.
+
 ## Key Features
 
 - **True VS Code Backend**: Runs as a standard VS Code extension with full access to your workspace, terminals and settings.
@@ -73,6 +75,10 @@ The server exposes two real-time endpoints for maximum efficiency:
 git clone https://github.com/your-username/mobile-vscode-project.git
 cd mobile-vscode-project
 
+# Configure the upstream remote so you can pull the latest changes
+git remote add upstream https://github.com/ales27pm/mobile-vscode-project.git
+git fetch upstream
+
 # Install all dependencies for all packages
 yarn install
 
@@ -104,6 +110,11 @@ Scan the QR code with Expo Go and enter the pairing token when prompted to secur
 | Backend     | VS Code Extension API, Node.js, Express, Apollo Server             |
 | API & Sync  | GraphQL, WebSockets, Y.js (CRDTs), simple-git                      |
 | Tooling     | Yarn Workspaces, ESLint, Jest, Maestro, GraphQL Code Generator     |
+
+## Testing
+
+Run `yarn lint` and `yarn test` to verify the codebase. Backend tests cover GraphQL resolvers, the server lifecycle, and filesystem watchers.
+
 
 ## Contributing
 

--- a/apps/backend/__mocks__/express.ts
+++ b/apps/backend/__mocks__/express.ts
@@ -1,0 +1,13 @@
+const use = jest.fn();
+const json = jest.fn(() => 'json');
+
+interface ExpressMock extends jest.Mock {
+  json: jest.Mock;
+  __mocks: { use: jest.Mock; json: jest.Mock; expressMock: jest.Mock };
+}
+
+const expressMock = jest.fn(() => ({ use })) as ExpressMock;
+expressMock.json = json;
+expressMock.__mocks = { use, json, expressMock };
+
+export = expressMock;

--- a/apps/backend/__mocks__/https.ts
+++ b/apps/backend/__mocks__/https.ts
@@ -1,0 +1,5 @@
+const listen = jest.fn((port: number, cb: () => void) => cb());
+const close = jest.fn((cb: () => void) => cb());
+const on = jest.fn();
+export const __mocks = { listen, close, on };
+export const createServer = jest.fn(() => ({ listen, close, on }));

--- a/apps/backend/__mocks__/vscode.ts
+++ b/apps/backend/__mocks__/vscode.ts
@@ -1,0 +1,37 @@
+const vscode = {
+  workspace: {
+    workspaceFolders: [] as unknown[],
+    getWorkspaceFolder: jest.fn(),
+    fs: {
+      readDirectory: jest.fn(),
+      readFile: jest.fn(),
+      writeFile: jest.fn(),
+    },
+    createFileSystemWatcher: jest.fn(),
+    asRelativePath: jest.fn(),
+    getConfiguration: jest.fn(() => ({ get: jest.fn() })),
+  },
+  Uri: {
+    parse: (s: string) => ({ fsPath: s.replace('file://',''), toString: () => s }),
+    file: (p: string) => ({ fsPath: p, toString: () => `file://${p}` }),
+  },
+  RelativePattern: function(workspace: { uri: { fsPath: string } }, pattern: string) {
+    return { baseUri: workspace.uri, pattern } as unknown;
+  },
+  FileType: { Directory: 2 },
+  commands: { executeCommand: jest.fn() },
+  extensions: { all: [] as unknown[] },
+  window: {
+    showWarningMessage: jest.fn(),
+    showErrorMessage: jest.fn(),
+    showInformationMessage: jest.fn(),
+  },
+  debug: {
+    onDidStartDebugSession: jest.fn(),
+    onDidTerminateDebugSession: jest.fn(),
+    onDidReceiveDebugSessionCustomEvent: jest.fn(),
+    startDebugging: jest.fn(),
+    stopDebugging: jest.fn(),
+  },
+};
+module.exports = vscode;

--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleNameMapper: {
+    '^vscode$': '<rootDir>/__mocks__/vscode.ts',
+  },
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -51,9 +51,11 @@
     "graphql-subscriptions": "^2.0.0",
     "graphql-ws": "^5.11.0",
     "jsonwebtoken": "^9.0.0",
+    "lru-cache": "^11.1.0",
     "simple-git": "^3.19.0",
     "ws": "^8.12.0",
-    "y-websocket": "^1.5.0"
+    "y-websocket": "^1.5.0",
+    "yjs": "^13.5.43"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/apps/backend/src/constants.ts
+++ b/apps/backend/src/constants.ts
@@ -1,0 +1,2 @@
+export const FS_EVENT = 'FS_EVENT';
+export const DEBUG_EVENT = 'DEBUG_EVENT';

--- a/apps/backend/src/core/auth.ts
+++ b/apps/backend/src/core/auth.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Express, Request } from 'express';
+import { Express, Request, Response, NextFunction } from 'express';
 import * as jwt from 'jsonwebtoken';
 import { randomBytes } from 'crypto';
 import { updateStatusBar } from '../ui/statusBar';
@@ -50,10 +50,10 @@ export async function ensureAuthContext(): Promise<AuthContext | null> {
     };
 }
 
-type RequestWithUser = Request & { user?: string | jwt.JwtPayload };
+export type RequestWithUser = Request & { user?: string | jwt.JwtPayload };
 
 export function pairingMiddleware(authContext: AuthContext) {
-    return (req: RequestWithUser, res: any, next: any) => {
+    return (req: RequestWithUser, res: Response, next: NextFunction) => {
         if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
             return res.status(400).json({ error: 'Invalid request body' });
         }
@@ -82,7 +82,7 @@ export function pairingMiddleware(authContext: AuthContext) {
 }
 
 export function jwtAuthMiddleware(authContext: AuthContext) {
-    return (req: RequestWithUser, res: any, next: any) => {
+    return (req: RequestWithUser, res: Response, next: NextFunction) => {
         const authHeader = req.headers.authorization;
         if (!authHeader || typeof authHeader !== 'string' || !authHeader.startsWith('Bearer ')) {
             return res.status(401).json({ error: 'Malformed or missing Authorization header' });

--- a/apps/backend/src/core/server.test.ts
+++ b/apps/backend/src/core/server.test.ts
@@ -1,0 +1,109 @@
+import { startServer, stopServer } from './server';
+import * as vscode from 'vscode';
+import { ensureAuthContext } from './auth';
+import { initializeFileSystemWatcher, disposeFileSystemWatcher } from '../watchers/fileSystemWatcher';
+
+jest.mock('./auth');
+jest.mock('../watchers/fileSystemWatcher');
+
+jest.mock('https', () => require('../../__mocks__/https'), { virtual: true });
+jest.mock('express', () => require('../../__mocks__/express'), { virtual: true });
+const { __mocks: httpsMocks } = jest.requireMock('https');
+const { listen, close } = httpsMocks;
+const expressModule = jest.requireMock('express');
+const expressMock = expressModule.__mocks.expressMock as jest.Mock;
+
+const start = jest.fn(() => Promise.resolve());
+const applyMiddleware = jest.fn();
+const stop = jest.fn();
+class FakeApolloServer {
+    start = start;
+    applyMiddleware = applyMiddleware;
+    stop = stop;
+}
+
+jest.mock(
+    'apollo-server-express',
+    () => ({
+        ApolloServer: jest.fn(() => new FakeApolloServer()),
+        gql: (literals: TemplateStringsArray, ...placeholders: string[]) =>
+            literals.reduce((acc, lit, i) => acc + (placeholders[i - 1] ?? '') + lit),
+    }),
+    { virtual: true }
+);
+
+jest.mock('@graphql-tools/schema', () => ({ makeExecutableSchema: jest.fn(() => 'schema') }), { virtual: true });
+
+const ws = { on: jest.fn(), handleUpgrade: jest.fn(), close: jest.fn() };
+jest.mock('ws', () => ({ WebSocketServer: jest.fn(() => ws) }), { virtual: true });
+
+jest.mock('graphql-ws/lib/use/ws', () => ({ useServer: jest.fn(() => ({ dispose: jest.fn() })) }), { virtual: true });
+
+jest.mock('y-websocket/bin/utils.js', () => ({ setupWSConnection: jest.fn(), setPersistence: jest.fn() }), { virtual: true });
+
+jest.mock('yjs', () => ({}), { virtual: true });
+
+jest.mock(
+    'lodash.debounce',
+    () =>
+        (fn: (...args: unknown[]) => void, wait = 300) => {
+            let timeout: NodeJS.Timeout | undefined;
+            const debounced = (...args: unknown[]) => {
+                clearTimeout(timeout);
+                timeout = setTimeout(() => fn(...args), wait);
+            };
+            (debounced as unknown as { flush(): void }).flush = () => {
+                clearTimeout(timeout);
+                fn();
+            };
+            return debounced;
+        },
+    { virtual: true }
+);
+
+jest.mock('fs', () => ({
+    existsSync: jest.fn(() => true),
+    readFileSync: jest.fn(() => Buffer.from('data')),
+}), { virtual: true });
+
+jest.mock('../graphql/resolvers', () => ({ getResolvers: jest.fn(() => ({})) }), { virtual: true });
+
+jest.mock('../ui/statusBar', () => ({ updateStatusBar: jest.fn() }), { virtual: true });
+
+jest.mock('path', () => ({ join: (...parts: string[]) => parts.join('/') }), { virtual: true });
+
+describe('server start/stop', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+        (ensureAuthContext as jest.Mock).mockResolvedValue({ jwtSecret: 'a', pairingToken: 'b', isPaired: false });
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({ get: jest.fn(() => 4000) });
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    it('starts and stops server', async () => {
+        const context = { extensionPath: '/ext' } as vscode.ExtensionContext;
+        await startServer(context);
+        await Promise.resolve();
+        expect(expressMock).toHaveBeenCalled();
+        expect(start).toHaveBeenCalled();
+        expect(listen).toHaveBeenCalledWith(4000, expect.any(Function));
+        expect(initializeFileSystemWatcher).toHaveBeenCalled();
+        stopServer();
+        expect(close).toHaveBeenCalled();
+        expect(stop).toHaveBeenCalled();
+        expect(disposeFileSystemWatcher).toHaveBeenCalled();
+    });
+
+    it('warns when already running', async () => {
+        const context = { extensionPath: '/ext' } as vscode.ExtensionContext;
+        await startServer(context);
+        await Promise.resolve();
+        await startServer(context);
+        expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+    });
+});

--- a/apps/backend/src/graphql/resolvers.test.ts
+++ b/apps/backend/src/graphql/resolvers.test.ts
@@ -1,0 +1,49 @@
+import { getResolvers } from './resolvers';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+jest.mock('fs');
+
+const readDirectory: jest.Mock = vscode.workspace.fs.readDirectory as jest.Mock;
+const readFile: jest.Mock = vscode.workspace.fs.readFile as jest.Mock;
+const writeFile: jest.Mock = vscode.workspace.fs.writeFile as jest.Mock;
+const getWorkspaceFolder: jest.Mock = vscode.workspace.getWorkspaceFolder as jest.Mock;
+let workspaceFolder: vscode.WorkspaceFolder;
+
+beforeEach(() => {
+    workspaceFolder = {
+        name: 'test',
+        uri: { fsPath: '/workspace/test', toString: () => 'file:///workspace/test' },
+    } as unknown as vscode.WorkspaceFolder;
+    (vscode.workspace as unknown as { workspaceFolders: vscode.WorkspaceFolder[] | undefined }).workspaceFolders = [workspaceFolder];
+    (fs.realpathSync.native as jest.Mock).mockImplementation((p: string) => p);
+    readDirectory.mockResolvedValue([['file.txt', 0], ['folder', 2]]);
+    readFile.mockResolvedValue(Buffer.from('content'));
+    writeFile.mockResolvedValue(undefined);
+    getWorkspaceFolder.mockReturnValue(workspaceFolder);
+    (vscode.workspace.asRelativePath as jest.Mock).mockImplementation((uri: vscode.Uri) => uri.fsPath.replace('/workspace/test/', ''));
+});
+
+test('lists workspaces', () => {
+    const resolvers = getResolvers();
+    expect(resolvers.Query.listWorkspaces()).toEqual([
+        { name: 'test', uri: 'file:///workspace/test' },
+    ]);
+});
+
+test('lists directory contents', async () => {
+    const resolvers = getResolvers();
+    const result = await resolvers.Query.listDirectory(undefined, { workspaceUri: 'file:///workspace/test', path: '' });
+    expect(readDirectory).toHaveBeenCalled();
+    expect(result).toEqual([
+        { name: 'file.txt', path: 'file.txt', isDirectory: false },
+        { name: 'folder', path: 'folder', isDirectory: true },
+    ]);
+});
+
+test('writes file', async () => {
+    const resolvers = getResolvers();
+    const ok = await resolvers.Mutation.writeFile(undefined, { workspaceUri: 'file:///workspace/test', path: 'new.txt', content: 'hello' });
+    expect(writeFile).toHaveBeenCalled();
+    expect(ok).toBe(true);
+});

--- a/apps/backend/src/graphql/resolvers.ts
+++ b/apps/backend/src/graphql/resolvers.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import simpleGit from 'simple-git';
 import { pubsub } from './pubsub';
+import { FS_EVENT, DEBUG_EVENT } from '../constants';
+import { getGitProvider } from '../providers/gitProvider';
+import { getDebugProvider } from '../providers/debugProvider';
 
 const getWorkspace = (uri: string): vscode.WorkspaceFolder => {
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(uri));
@@ -31,108 +33,107 @@ const getValidatedUri = (workspace: vscode.WorkspaceFolder, relativePath: string
     return vscode.Uri.file(finalPath);
 };
 
-export function getResolvers() {
-    return {
-        Query: {
-            listWorkspaces: () => {
-                return vscode.workspace.workspaceFolders?.map(f => ({ name: f.name, uri: f.uri.toString() })) ?? [];
-            },
-            listDirectory: async (_: any, { workspaceUri, path = '' }: { workspaceUri: string, path?: string }) => {
-                const workspace = getWorkspace(workspaceUri);
-                const directoryUri = getValidatedUri(workspace, path);
-                const items = await vscode.workspace.fs.readDirectory(directoryUri);
-                return items.map(([name, type]) => ({
-                    name,
-                    path: `${path ? path + '/' : ''}${name}`,
-                    isDirectory: type === vscode.FileType.Directory,
-                }));
-            },
-            readFile: async (_: any, { workspaceUri, path }: { workspaceUri: string, path: string }) => {
-                const workspace = getWorkspace(workspaceUri);
-                const fileUri = getValidatedUri(workspace, path);
-                const content = await vscode.workspace.fs.readFile(fileUri);
-                return content.toString();
-            },
-            search: async (_: any, { workspaceUri, query }: { workspaceUri: string, query: string }) => {
-                const workspace = getWorkspace(workspaceUri);
-                const results: { file: string; line: number; text: string }[] = [];
-                await (vscode.workspace as any).findTextInFiles(
-                    { pattern: query },
-                    { include: new vscode.RelativePattern(workspace, '**/*'), exclude: '**/node_modules/**' },
-                    (result: any) => {
-                        if ('preview' in result && result.ranges && result.ranges.length > 0) {
-                            results.push({
-                                file: vscode.workspace.asRelativePath(result.uri, false),
-                                line: result.ranges[0].start.line + 1,
-                                text: result.preview.text.trim()
-                            });
-                        }
+const gitProvider = getGitProvider();
+const debugProvider = getDebugProvider();
+
+const resolvers = {
+    Query: {
+        listWorkspaces: () => {
+            return vscode.workspace.workspaceFolders?.map(f => ({ name: f.name, uri: f.uri.toString() })) ?? [];
+        },
+        listDirectory: async (_: unknown, { workspaceUri, path = '' }: { workspaceUri: string; path?: string }) => {
+            const workspace = getWorkspace(workspaceUri);
+            const directoryUri = getValidatedUri(workspace, path);
+            const items = await vscode.workspace.fs.readDirectory(directoryUri);
+            return items.map(([name, type]) => ({
+                name,
+                path: `${path ? path + '/' : ''}${name}`,
+                isDirectory: type === vscode.FileType.Directory,
+            }));
+        },
+        readFile: async (_: unknown, { workspaceUri, path }: { workspaceUri: string; path: string }) => {
+            const workspace = getWorkspace(workspaceUri);
+            const fileUri = getValidatedUri(workspace, path);
+            const content = await vscode.workspace.fs.readFile(fileUri);
+            return content.toString();
+        },
+        search: async (_: unknown, { workspaceUri, query }: { workspaceUri: string; query: string }) => {
+            const workspace = getWorkspace(workspaceUri);
+            const results: { file: string; line: number; text: string }[] = [];
+            const workspaceWithSearch = vscode.workspace as unknown as {
+                findTextInFiles: (
+                    query: { pattern: string },
+                    opts: { include: vscode.RelativePattern; exclude: string },
+                    onResult: (result: { uri: vscode.Uri; ranges: vscode.Range[]; preview: { text: string } }) => void
+                ) => void;
+            };
+            await workspaceWithSearch.findTextInFiles(
+                { pattern: query },
+                { include: new vscode.RelativePattern(workspace, '**/*'), exclude: '**/node_modules/**' },
+                (result) => {
+                    if ('preview' in result && result.ranges && result.ranges.length > 0) {
+                        results.push({
+                            file: vscode.workspace.asRelativePath(result.uri, false),
+                            line: result.ranges[0].start.line + 1,
+                            text: result.preview.text.trim(),
+                        });
                     }
-                );
-                return results;
-            },
-            gitStatus: async (_: any, { workspaceUri }: { workspaceUri: string }) => {
-                const workspace = getWorkspace(workspaceUri);
-                const git = simpleGit(workspace.uri.fsPath);
-                if (!(await git.checkIsRepo())) return { branch: 'Not a Git repository', changes: [] };
-                const s = await git.status();
-                return {
-                    branch: s.current || 'detached',
-                    changes: s.files.map(f => `${f.path} (${f.working_dir})`),
-                };
-            },
-            extensions: () => {
-                 return vscode.extensions.all
-                    .filter(ext => !ext.id.startsWith('vscode.') && !ext.id.startsWith('ms-vscode.'))
-                    .map(ext => ({
-                        id: ext.id,
-                        name: ext.packageJSON.displayName || ext.packageJSON.name,
-                        description: ext.packageJSON.description,
-                        installed: true,
-                    }));
-            }
+                }
+            );
+            return results;
         },
-        Mutation: {
-            writeFile: async (_: any, { workspaceUri, path, content }: { workspaceUri: string, path: string; content: string }) => {
-                const workspace = getWorkspace(workspaceUri);
-                const fileUri = getValidatedUri(workspace, path);
-                const newContent = Buffer.from(content, 'utf-8');
-                await vscode.workspace.fs.writeFile(fileUri, newContent);
+        extensions: () => {
+             return vscode.extensions.all
+                .filter(ext => !ext.id.startsWith('vscode.') && !ext.id.startsWith('ms-vscode.'))
+                .map(ext => ({
+                    id: ext.id,
+                    name: ext.packageJSON.displayName || ext.packageJSON.name,
+                    description: ext.packageJSON.description,
+                    installed: true,
+                }));
+        },
+        ...gitProvider.Query,
+        ...debugProvider.Query,
+    },
+    Mutation: {
+        writeFile: async (_: unknown, { workspaceUri, path, content }: { workspaceUri: string; path: string; content: string }) => {
+            const workspace = getWorkspace(workspaceUri);
+            const fileUri = getValidatedUri(workspace, path);
+            const newContent = Buffer.from(content, 'utf-8');
+            await vscode.workspace.fs.writeFile(fileUri, newContent);
+            return true;
+        },
+        installExtension: async (_: unknown, { id }: { id: string }) => {
+            try {
+                await vscode.commands.executeCommand('workbench.extensions.installExtension', id);
                 return true;
-            },
-            commit: async (_: any, { workspaceUri, message }: { workspaceUri: string, message: string }) => {
-              const workspace = getWorkspace(workspaceUri);
-              await simpleGit(workspace.uri.fsPath).add('.').commit(message);
-              return true;
-            },
-            push: async (_: any, { workspaceUri }: { workspaceUri: string }) => {
-              const workspace = getWorkspace(workspaceUri);
-              await simpleGit(workspace.uri.fsPath).push();
-              return true;
-            },
-            installExtension: async (_: any, { id }: { id: string }) => {
-                try {
-                    await vscode.commands.executeCommand('workbench.extensions.installExtension', id);
-                    return true;
-                } catch (err) {
-                    console.error(err);
-                    return false;
-                }
-            },
-            uninstallExtension: async (_: any, { id }: { id: string }) => {
-                try {
-                    await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', id);
-                    return true;
-                } catch (err) {
-                    console.error(err);
-                    return false;
-                }
+            } catch (err) {
+                console.error(err);
+                return false;
             }
         },
-        Subscription: {
-            fsEvent: {
-                subscribe: () => pubsub.asyncIterator(['FS_EVENT']),
-            },
+        uninstallExtension: async (_: unknown, { id }: { id: string }) => {
+            try {
+                await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', id);
+                return true;
+            } catch (err) {
+                console.error(err);
+                return false;
+            }
         },
-    };
+        ...gitProvider.Mutation,
+        ...debugProvider.Mutation,
+    },
+    Subscription: {
+        fsEvent: {
+            subscribe: () => pubsub.asyncIterator([FS_EVENT]),
+        },
+        debuggerEvent: {
+            subscribe: () => pubsub.asyncIterator([DEBUG_EVENT]),
+        },
+    },
+};
+
+export function getResolvers() {
+    return resolvers;
 }

--- a/apps/backend/src/providers/debugProvider.ts
+++ b/apps/backend/src/providers/debugProvider.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+import { pubsub } from '../graphql/pubsub';
+import { DEBUG_EVENT } from '../constants';
+
+let activeSession: vscode.DebugSession | undefined;
+
+vscode.debug.onDidStartDebugSession(session => {
+  activeSession = session;
+  try {
+    pubsub.publish(DEBUG_EVENT, {
+      debuggerEvent: { event: 'start', body: `Session '${session.name}' started.` },
+    });
+  } catch (error) {
+    console.error('Failed to publish start debug event:', error);
+  }
+});
+
+vscode.debug.onDidTerminateDebugSession(() => {
+  activeSession = undefined;
+  try {
+    pubsub.publish(DEBUG_EVENT, { debuggerEvent: { event: 'stop', body: 'Session terminated.' } });
+  } catch (error) {
+    console.error('Failed to publish stop debug event:', error);
+  }
+});
+
+const getOutputFromBody = (body: unknown): string =>
+  typeof body === 'object' &&
+  body !== null &&
+  'output' in body &&
+  typeof (body as { output: unknown }).output === 'string'
+    ? (body as { output: string }).output
+    : '';
+
+vscode.debug.onDidReceiveDebugSessionCustomEvent(e => {
+  try {
+    if (activeSession && e.session === activeSession && e.event === 'output') {
+      const output = getOutputFromBody(e.body);
+      pubsub.publish(DEBUG_EVENT, { debuggerEvent: { event: 'output', body: output } });
+    }
+  } catch (error) {
+    console.error('Error handling debug session custom event:', error);
+  }
+});
+
+export const getDebugProvider = () => ({
+  Query: {
+    getLaunchConfigurations: (_: unknown, { workspaceUri }: { workspaceUri: string }) => {
+      try {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(workspaceUri));
+        if (!workspaceFolder) return [];
+        const launchConfig = vscode.workspace.getConfiguration('launch', workspaceFolder.uri);
+        return launchConfig.get<vscode.DebugConfiguration[]>('configurations') ?? [];
+      } catch (error) {
+        console.error('Error getting launch configurations:', error);
+        return [];
+      }
+    },
+  },
+  Mutation: {
+    startDebugging: async (_: unknown, { workspaceUri, configName }: { workspaceUri: string; configName: string }) => {
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(workspaceUri));
+      if (!workspaceFolder) return false;
+      return vscode.debug.startDebugging(workspaceFolder, configName);
+    },
+    stopDebugging: async () => {
+      if (!activeSession) return false;
+      const result = await vscode.debug.stopDebugging(activeSession);
+      return result;
+    },
+  },
+});
+
+export const testingExports = {
+  __setActiveSession: (session: vscode.DebugSession | undefined) => { activeSession = session; },
+};

--- a/apps/backend/src/providers/gitProvider.test.ts
+++ b/apps/backend/src/providers/gitProvider.test.ts
@@ -1,0 +1,64 @@
+import { getGitProvider } from './gitProvider';
+import simpleGit from 'simple-git';
+import * as vscode from 'vscode';
+
+jest.mock('simple-git');
+
+const mockGit = {
+  checkIsRepo: jest.fn(),
+  status: jest.fn(),
+  add: jest.fn(),
+  reset: jest.fn(),
+  diff: jest.fn(),
+  commit: jest.fn(),
+  push: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (simpleGit as jest.Mock).mockReturnValue(mockGit);
+  mockGit.checkIsRepo.mockResolvedValue(true);
+  (vscode.workspace.getWorkspaceFolder as jest.Mock).mockReturnValue({ uri: { fsPath: '/test' } });
+});
+
+describe('gitProvider', () => {
+  const provider = getGitProvider();
+  const args = { workspaceUri: 'file:///test' };
+
+  it('gitStatus returns correct status', async () => {
+    mockGit.status.mockResolvedValue({
+      current: 'main',
+      files: [
+        { path: 'a.txt', index: 'A', working_dir: ' ' },
+        { path: 'b.txt', index: ' ', working_dir: 'M' },
+      ],
+    });
+
+    const status = await provider.Query.gitStatus(null, args);
+    expect(status.branch).toBe('main');
+    expect(status.staged).toEqual(['a.txt']);
+    expect(status.unstaged).toEqual(['b.txt']);
+  });
+
+  it('gitDiff returns diff string', async () => {
+    mockGit.diff.mockResolvedValue('diff');
+    const diff = await provider.Query.gitDiff(null, { ...args, file: 'file.txt' });
+    expect(diff).toBe('diff');
+    expect(mockGit.diff).toHaveBeenCalledWith(['file.txt']);
+  });
+
+  it('gitStage stages file', async () => {
+    await provider.Mutation.gitStage(null, { ...args, file: 'x' });
+    expect(mockGit.add).toHaveBeenCalledWith('x');
+  });
+
+  it('gitUnstage unstages file', async () => {
+    await provider.Mutation.gitUnstage(null, { ...args, file: 'x' });
+    expect(mockGit.reset).toHaveBeenCalledWith(['--', 'x']);
+  });
+
+  it('commit creates commit', async () => {
+    await provider.Mutation.commit(null, { ...args, message: 'm' });
+    expect(mockGit.commit).toHaveBeenCalledWith('m');
+  });
+});

--- a/apps/backend/src/providers/gitProvider.ts
+++ b/apps/backend/src/providers/gitProvider.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+import simpleGit, { SimpleGit } from 'simple-git';
+
+const getGit = (workspaceUri: string): SimpleGit | null => {
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(workspaceUri));
+  if (!workspaceFolder) return null;
+  return simpleGit(workspaceFolder.uri.fsPath);
+};
+
+export const getGitProvider = () => ({
+  Query: {
+    gitStatus: async (_: unknown, { workspaceUri }: { workspaceUri: string }) => {
+      const git = getGit(workspaceUri);
+      if (!git || !(await git.checkIsRepo())) return { branch: 'Not a repo', staged: [], unstaged: [] };
+      const s = await git.status();
+      const unstaged = s.files
+        .filter(f => f.working_dir !== ' ')
+        .map(f => f.path);
+      const staged = s.files
+        .filter(f => f.index !== ' ')
+        .map(f => f.path);
+      return {
+        branch: s.current || 'detached',
+        staged,
+        unstaged,
+      };
+    },
+    gitDiff: async (_: unknown, { workspaceUri, file }: { workspaceUri: string; file: string }) => {
+      const git = getGit(workspaceUri);
+      if (!git) return '';
+      return git.diff([file]);
+    },
+  },
+  Mutation: {
+    gitStage: async (_: unknown, { workspaceUri, file }: { workspaceUri: string; file: string }) => {
+      const git = getGit(workspaceUri);
+      if (!git) return false;
+      await git.add(file);
+      return true;
+    },
+    gitUnstage: async (_: unknown, { workspaceUri, file }: { workspaceUri: string; file: string }) => {
+      const git = getGit(workspaceUri);
+      if (!git) return false;
+      await git.reset(['--', file]);
+      return true;
+    },
+    commit: async (_: unknown, { workspaceUri, message }: { workspaceUri: string; message: string }) => {
+      const git = getGit(workspaceUri);
+      if (!git) return false;
+      await git.commit(message);
+      return true;
+    },
+    push: async (_: unknown, { workspaceUri }: { workspaceUri: string }) => {
+      const git = getGit(workspaceUri);
+      if (!git) return false;
+      await git.push();
+      return true;
+    },
+  },
+});

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -20,7 +20,19 @@ export default gql`
   
   type GitStatus {
     branch: String!
-    changes: [String!]!
+    staged: [String!]!
+    unstaged: [String!]!
+  }
+
+  type DebugConfiguration {
+    name: String!
+    type: String!
+    request: String!
+  }
+
+  type DebuggerEvent {
+    event: String!
+    body: String!
   }
 
   type FSEvent {
@@ -41,19 +53,26 @@ export default gql`
     readFile(workspaceUri: String!, path: String!): String
     search(workspaceUri: String!, query: String!): [SearchResult!]!
     gitStatus(workspaceUri: String!): GitStatus!
+    gitDiff(workspaceUri: String!, file: String!): String!
+    getLaunchConfigurations(workspaceUri: String!): [DebugConfiguration!]!
     extensions: [Extension!]!
   }
 
   type Mutation {
     pairWithServer(pairingToken: String!): String
     writeFile(workspaceUri: String!, path: String!, content: String!): Boolean!
+    gitStage(workspaceUri: String!, file: String!): Boolean!
+    gitUnstage(workspaceUri: String!, file: String!): Boolean!
     commit(workspaceUri: String!, message: String!): Boolean!
     push(workspaceUri: String!): Boolean!
+    startDebugging(workspaceUri: String!, configName: String!): Boolean!
+    stopDebugging: Boolean!
     installExtension(id: String!): Boolean!
     uninstallExtension(id: String!): Boolean!
   }
 
   type Subscription {
     fsEvent: FSEvent!
+    debuggerEvent: DebuggerEvent!
   }
 `;

--- a/apps/backend/src/types/test-shims.d.ts
+++ b/apps/backend/src/types/test-shims.d.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'yjs' {
+    namespace Y {
+        interface Doc {
+            on(event: string, listener: (...args: any[]) => void): void;
+            destroy(): void;
+        }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const Y: any;
+    export = Y;
+}
+declare module 'lodash.debounce' {
+    export interface DebouncedFunc<T extends (...args: any[]) => any> {
+        (...args: Parameters<T>): void;
+        cancel(): void;
+        flush(): void;
+    }
+    export default function debounce<T extends (...args: any[]) => any>(
+        func: T,
+        wait?: number
+    ): DebouncedFunc<T>;
+}
+declare module 'lru-cache' {
+    export class LRUCache<K = unknown, V = unknown> {
+        constructor(opts?: unknown);
+        get(key: K): V | undefined;
+        set(key: K, value: V): void;
+        has(key: K): boolean;
+        delete(key: K): void;
+    }
+}

--- a/apps/backend/src/types/y-websocket.d.ts
+++ b/apps/backend/src/types/y-websocket.d.ts
@@ -8,7 +8,7 @@ declare module 'y-websocket/bin/utils.js' {
     export interface Persistence {
         bindState: (docName: string, ydoc: Doc) => void | Promise<void>;
         writeState: (docName: string, ydoc: Doc) => void | Promise<void>;
-        provider?: any;
+        provider?: unknown;
     }
 
     export function setPersistence(p: Persistence): void;

--- a/apps/backend/src/watchers/fileSystemWatcher.test.ts
+++ b/apps/backend/src/watchers/fileSystemWatcher.test.ts
@@ -1,0 +1,70 @@
+import { initializeFileSystemWatcher, disposeFileSystemWatcher } from './fileSystemWatcher';
+import { pubsub } from '../graphql/pubsub';
+import { FS_EVENT } from '../constants';
+import * as vscode from 'vscode';
+
+type Callback = (uri: vscode.Uri) => void;
+
+const createFileSystemWatcher = vscode.workspace.createFileSystemWatcher as jest.Mock;
+const getWorkspaceFolder = vscode.workspace.getWorkspaceFolder as jest.Mock;
+const asRelativePath = vscode.workspace.asRelativePath as jest.Mock;
+
+let onCreate: Callback | undefined;
+let onChange: Callback | undefined;
+let onDelete: Callback | undefined;
+const dispose = jest.fn();
+
+jest.mock('../graphql/pubsub', () => ({
+    pubsub: { publish: jest.fn() }
+}));
+
+beforeEach(() => {
+    (pubsub.publish as jest.Mock).mockClear();
+    createFileSystemWatcher.mockImplementation(() => {
+        return {
+            onDidCreate: (cb: Callback) => {
+                onCreate = cb;
+            },
+            onDidChange: (cb: Callback) => {
+                onChange = cb;
+            },
+            onDidDelete: (cb: Callback) => {
+                onDelete = cb;
+            },
+            dispose,
+        } as unknown as vscode.FileSystemWatcher;
+    });
+    getWorkspaceFolder.mockReturnValue({ uri: { fsPath: '/workspace/test' } });
+    asRelativePath.mockImplementation((uri: vscode.Uri) => uri.fsPath.replace('/workspace/test/', ''));
+    onCreate = undefined;
+    onChange = undefined;
+    onDelete = undefined;
+    dispose.mockClear();
+});
+
+it('publishes events for file changes', () => {
+    initializeFileSystemWatcher();
+    expect(createFileSystemWatcher).toHaveBeenCalledWith('**/*');
+    const uri = { fsPath: '/workspace/test/foo.txt' } as vscode.Uri;
+    onCreate?.(uri);
+    onChange?.(uri);
+    onDelete?.(uri);
+    expect(pubsub.publish).toHaveBeenCalledTimes(3);
+    expect(pubsub.publish).toHaveBeenCalledWith(FS_EVENT, { fsEvent: { event: 'create', path: 'foo.txt' } });
+    expect(pubsub.publish).toHaveBeenCalledWith(FS_EVENT, { fsEvent: { event: 'change', path: 'foo.txt' } });
+    expect(pubsub.publish).toHaveBeenCalledWith(FS_EVENT, { fsEvent: { event: 'delete', path: 'foo.txt' } });
+});
+
+it('does not reinitialize watcher if already set', () => {
+    initializeFileSystemWatcher();
+    initializeFileSystemWatcher();
+    expect(createFileSystemWatcher).toHaveBeenCalledTimes(1);
+});
+
+it('disposes watcher', () => {
+    initializeFileSystemWatcher();
+    disposeFileSystemWatcher();
+    expect(dispose).toHaveBeenCalled();
+    // calling again should be safe
+    disposeFileSystemWatcher();
+});

--- a/apps/backend/src/watchers/fileSystemWatcher.ts
+++ b/apps/backend/src/watchers/fileSystemWatcher.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pubsub } from '../graphql/pubsub';
+import { FS_EVENT } from '../constants';
 
 let fileWatcher: vscode.FileSystemWatcher | null = null;
 
@@ -14,7 +15,7 @@ export function initializeFileSystemWatcher() {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
         if (workspaceFolder) {
             const relPath = vscode.workspace.asRelativePath(uri, false);
-            pubsub.publish('FS_EVENT', {
+            pubsub.publish(FS_EVENT, {
                 fsEvent: { event, path: relPath }
             });
         }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.0",
     "@react-native-async-storage/async-storage": "^1.20.1",
+    "@react-native-picker/picker": "^2.4.10",
     "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
@@ -22,6 +23,7 @@
     "react-native": "0.71.8",
     "react-native-monaco-editor": "^0.1.0",
     "react-native-safe-area-context": "4.5.0",
+    "react-native-screens": "^3.20.0",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-vector-icons": "^9.2.0",
     "react-native-webview": "11.26.0",

--- a/apps/mobile/src/apolloClient.ts
+++ b/apps/mobile/src/apolloClient.ts
@@ -6,7 +6,10 @@ import { setContext } from '@apollo/client/link/context';
 import { GRAPHQL_URL, WS_URL } from './config';
 import { useAuthStore } from './state/authStore';
 
-const httpLink = new HttpLink({ uri: GRAPHQL_URL, fetch: fetch as any });
+const httpLink = new HttpLink({
+  uri: GRAPHQL_URL,
+  fetch,
+});
 
 const authLink = setContext((_, { headers }) => {
   const token = useAuthStore.getState().token;

--- a/apps/mobile/src/hooks/useErrorAlert.ts
+++ b/apps/mobile/src/hooks/useErrorAlert.ts
@@ -1,0 +1,9 @@
+import { Alert } from 'react-native';
+import { useCallback } from 'react';
+
+export function useErrorAlert(message: string) {
+  return useCallback((err: unknown) => {
+    console.error(err);
+    Alert.alert(message);
+  }, [message]);
+}

--- a/apps/mobile/src/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator.tsx
@@ -6,6 +6,7 @@ import Explorer from '../screens/Explorer';
 import Git from '../screens/Git';
 import Extensions from '../screens/Extensions';
 import Search from '../screens/Search';
+import Debug from '../screens/Debug';
 
 const Tab = createBottomTabNavigator();
 
@@ -14,6 +15,7 @@ const iconMap: Record<string, string> = {
   Search: 'magnify',
   Git: 'source-branch',
   Extensions: 'puzzle',
+  Debug: 'bug',
 };
 
 export default function MainTabNavigator({ route }) {
@@ -31,6 +33,7 @@ export default function MainTabNavigator({ route }) {
       <Tab.Screen name="Search" component={Search} initialParams={{ workspaceUri }} />
       <Tab.Screen name="Git" component={Git} initialParams={{ workspaceUri }} />
       <Tab.Screen name="Extensions" component={Extensions} initialParams={{ workspaceUri }} />
+      <Tab.Screen name="Debug" component={Debug} initialParams={{ workspaceUri }} />
     </Tab.Navigator>
   );
 }

--- a/apps/mobile/src/screens/Debug.tsx
+++ b/apps/mobile/src/screens/Debug.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback } from 'react';
+import { View, Text, Button, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { useQuery, useMutation, useSubscription } from '@apollo/client';
+import { useErrorAlert } from '../hooks/useErrorAlert';
+import { GetLaunchConfigurationsDocument, StartDebuggingDocument, StopDebuggingDocument, DebuggerEventDocument } from 'shared/src/types';
+import { useDebugStore } from '../state/debugStore';
+
+export default function Debug({ route }) {
+  const { workspaceUri } = route.params;
+  const [selectedConfig, setSelectedConfig] = React.useState<string | null>(null);
+
+  const { data, loading } = useQuery(GetLaunchConfigurationsDocument, { variables: { workspaceUri } });
+
+  React.useEffect(() => {
+    if (
+      data &&
+      data?.getLaunchConfigurations?.length &&
+      !selectedConfig
+    ) {
+      setSelectedConfig(data.getLaunchConfigurations[0].name);
+    }
+  }, [data, selectedConfig]);
+  const startError = useErrorAlert('Failed to start debugging');
+  const stopError = useErrorAlert('Failed to stop debugging');
+  const [start, { loading: startLoading }] = useMutation(StartDebuggingDocument, {
+    onError: startError,
+  });
+  const [stop, { loading: stopLoading }] = useMutation(StopDebuggingDocument, {
+    onError: stopError,
+  });
+
+  const handleStart = useCallback(() => {
+    if (!selectedConfig) return;
+    start({ variables: { workspaceUri, configName: selectedConfig } });
+  }, [selectedConfig, start, workspaceUri]);
+
+  const handleStop = useCallback(() => {
+    stop();
+  }, [stop]);
+
+  const { logs, appendLog, clearLogs, setActive, isActive } = useDebugStore();
+
+  useSubscription(DebuggerEventDocument, {
+    onSubscriptionData: ({ subscriptionData }) => {
+      const event = subscriptionData.data?.debuggerEvent;
+      if (!event) return;
+      if (event.event === 'start') { setActive(true); clearLogs(); }
+      if (event.event === 'stop') setActive(false);
+      appendLog(`[${event.event}] ${event.body}`);
+    },
+  });
+
+  if (loading) return <ActivityIndicator />;
+
+  const configs = data?.getLaunchConfigurations ?? [];
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.controls}>
+        <Picker
+          selectedValue={selectedConfig}
+          onValueChange={(v) => setSelectedConfig(v)}
+          style={styles.picker}
+        >
+          {configs.map(c => <Picker.Item key={c.name} label={c.name} value={c.name} />)}
+        </Picker>
+        {!isActive ? (
+          <View style={styles.button}>
+            <Button
+              title="Start"
+              onPress={handleStart}
+              disabled={!selectedConfig || startLoading}
+            />
+          </View>
+        ) : (
+          <View style={styles.button}>
+            <Button
+              title="Stop"
+              onPress={handleStop}
+              disabled={stopLoading}
+              color="red"
+            />
+          </View>
+        )}
+      </View>
+      <FlatList
+        data={logs}
+        renderItem={({ item }) => <Text style={styles.log}>{item}</Text>}
+        keyExtractor={(_, idx) => String(idx)}
+        style={styles.logContainer}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 8 },
+  controls: { flexDirection: 'row', alignItems: 'center', borderBottomWidth: 1, borderColor: '#ccc', paddingBottom: 8 },
+  logContainer: { flex: 1, backgroundColor: '#1e1e1e', marginTop: 8, padding: 4 },
+  log: { color: 'white', fontFamily: 'monospace', fontSize: 12 },
+  picker: { flex: 1 },
+  button: { marginLeft: 8 },
+});

--- a/apps/mobile/src/screens/Git.tsx
+++ b/apps/mobile/src/screens/Git.tsx
@@ -1,41 +1,199 @@
-import React from 'react';
-import { View, Button, Text, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
-import { useQuery, useMutation } from '@apollo/client';
-import { GitStatusDocument, CommitDocument, PushDocument } from 'shared/src/types';
+import React, { useState, useCallback } from 'react';
+import { View, Button, Text, SectionList, ActivityIndicator, StyleSheet, TouchableOpacity, Modal, TextInput, ScrollView, Platform } from 'react-native';
+import { useQuery, useMutation, useLazyQuery } from '@apollo/client';
+import { useErrorAlert } from '../hooks/useErrorAlert';
+import { GitStatusDocument, GitDiffDocument, GitStageDocument, GitUnstageDocument, CommitDocument, PushDocument } from 'shared/src/types';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+const ChangeItem = React.memo(function ChangeItem({ file, staged, onStage, onUnstage, onViewDiff, loading }: {
+  file: string;
+  staged: boolean;
+  onStage(): void;
+  onUnstage(): void;
+  onViewDiff(): void;
+  loading: boolean;
+}) {
+  return (
+    <TouchableOpacity style={styles.changeItem} onLongPress={onViewDiff}>
+      <Icon name="file-document-outline" size={20} color="#555" style={{ marginRight: 8 }} />
+      <Text style={[styles.path, { marginRight: 8 }]} numberOfLines={1} ellipsizeMode="middle">
+        {file}
+      </Text>
+      <Button
+        title={staged ? 'Unstage' : 'Stage'}
+        onPress={staged ? onUnstage : onStage}
+        disabled={loading}
+      />
+    </TouchableOpacity>
+  );
+});
+
+function DiffModal({ visible, diff, onClose }: { visible: boolean; diff: string; onClose(): void }) {
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={{ flex: 1, padding: 16 }}>
+        <ScrollView style={{ flex: 1 }}>
+          <Text style={{ fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }) }}>{diff}</Text>
+        </ScrollView>
+        <Button title="Close" onPress={onClose} />
+      </View>
+    </Modal>
+  );
+}
+
+function CommitModal({ visible, message, onMessage, onCommit, onCancel, loading }: {
+  visible: boolean;
+  message: string;
+  onMessage(text: string): void;
+  onCommit(): void;
+  onCancel(): void;
+  loading: boolean;
+}) {
+  return (
+    <Modal visible={visible} transparent>
+      <View style={styles.modalContainer}>
+        <View style={styles.modalView}>
+          <TextInput
+            placeholder="Commit message"
+            onChangeText={onMessage}
+            value={message}
+            multiline
+            style={styles.commitInput}
+          />
+          <View style={{ marginBottom: 8 }}>
+            <Button title="Commit" onPress={onCommit} disabled={loading} />
+          </View>
+          <Button title="Cancel" onPress={onCancel} color="gray" />
+        </View>
+      </View>
+    </Modal>
+  );
+}
 
 export default function Git({ route }) {
   const { workspaceUri } = route.params;
-  const { data, loading, refetch } = useQuery(GitStatusDocument, { variables: { workspaceUri } });
-  const [commit, { loading: cLoading }] = useMutation(CommitDocument, { onCompleted: () => refetch() });
-  const [push, { loading: pLoading }] = useMutation(PushDocument, { onCompleted: () => refetch() });
+  const { data, loading, refetch } = useQuery(GitStatusDocument, { variables: { workspaceUri }, fetchPolicy: 'cache-and-network' });
+
+  const [commitMessage, setCommitMessage] = useState('');
+  const [isCommitModalVisible, setCommitModalVisible] = useState(false);
+  const [diff, setDiff] = useState('');
+  const [isDiffModalVisible, setDiffModalVisible] = useState(false);
+
+  const stageError = useErrorAlert('Failed to stage file');
+  const unstageError = useErrorAlert('Failed to unstage file');
+  const commitError = useErrorAlert('Commit failed');
+  const pushError = useErrorAlert('Push failed');
+  const diffError = useErrorAlert('Failed to load diff');
+
+  const [stage, { loading: stageLoading }] = useMutation(GitStageDocument, {
+    onCompleted: () => refetch(),
+    onError: stageError,
+  });
+  const [unstage, { loading: unstageLoading }] = useMutation(GitUnstageDocument, {
+    onCompleted: () => refetch(),
+    onError: unstageError,
+  });
+  const [commit, { loading: cLoading }] = useMutation(CommitDocument, {
+    onCompleted: () => {
+      setCommitModalVisible(false);
+      setCommitMessage('');
+      refetch();
+    },
+    onError: commitError,
+  });
+  const [push, { loading: pLoading }] = useMutation(PushDocument, {
+    onError: pushError,
+  });
+  const [getDiff] = useLazyQuery(GitDiffDocument, {
+    onError: diffError,
+  });
+  const handleViewDiff = useCallback(async (file: string) => {
+    const res = await getDiff({ variables: { workspaceUri, file } });
+    if (res.data?.gitDiff) {
+      setDiff(res.data.gitDiff);
+    } else {
+      setDiff('Could not load diff.');
+    }
+    setDiffModalVisible(true);
+  }, [getDiff, workspaceUri]);
+
+  const handleStage = useCallback((file: string) => {
+    stage({ variables: { workspaceUri, file } });
+  }, [stage, workspaceUri]);
+
+  const handleUnstage = useCallback((file: string) => {
+    unstage({ variables: { workspaceUri, file } });
+  }, [unstage, workspaceUri]);
+
+const renderChange = useCallback(({ item, section }: { item: { key: string; file: string }; section: { title: string } }) => {
+    const isStaged = section.title === 'Staged';
+    return (
+      <ChangeItem
+        file={item.file}
+        staged={isStaged}
+        onStage={() => handleStage(item.file)}
+        onUnstage={() => handleUnstage(item.file)}
+        onViewDiff={() => handleViewDiff(item.file)}
+        loading={stageLoading || unstageLoading}
+      />
+    );
+  }, [handleStage, handleUnstage, handleViewDiff, stageLoading, unstageLoading]);
+
+  if (loading && !data) return <ActivityIndicator style={styles.center} size="large" />;
+
+  const sections = [
+    {
+      title: 'Staged',
+      data: (data?.gitStatus.staged ?? []).map(f => ({ key: `staged-${f}`, file: f })),
+    },
+    {
+      title: 'Unstaged',
+      data: (data?.gitStatus.unstaged ?? []).map(f => ({ key: `unstaged-${f}`, file: f })),
+    },
+  ];
 
   return (
     <View style={styles.container}>
-      <Button title="Refresh" onPress={() => refetch()} disabled={loading} />
-      {loading ? <ActivityIndicator/> : (
-        <>
-            <Text style={styles.branch}>Branch: {data?.gitStatus.branch}</Text>
-            <Text style={styles.header}>Changes:</Text>
-            <FlatList
-                data={data?.gitStatus.changes}
-                keyExtractor={item => item}
-                renderItem={({ item }) => <Text style={styles.change}>{item}</Text>}
-                ListEmptyComponent={<Text style={styles.change}>No changes detected.</Text>}
-            />
-            <View style={styles.actions}>
-                <Button title="Commit All" onPress={() => commit({ variables: { workspaceUri, message: 'Commit from mobile' } })} disabled={cLoading || pLoading} />
-                <Button title="Push" onPress={() => push({ variables: { workspaceUri } })} disabled={cLoading || pLoading}/>
-            </View>
-        </>
-      )}
+      <DiffModal
+        visible={isDiffModalVisible}
+        diff={diff}
+        onClose={() => setDiffModalVisible(false)}
+      />
+
+      <CommitModal
+        visible={isCommitModalVisible}
+        message={commitMessage}
+        onMessage={setCommitMessage}
+        onCommit={() => commit({ variables: { workspaceUri, message: commitMessage } })}
+        onCancel={() => setCommitModalVisible(false)}
+        loading={cLoading}
+      />
+
+      <View style={styles.header}>
+        <Text>Branch: {data?.gitStatus.branch}</Text>
+        <Button title="Push" onPress={() => push({ variables: { workspaceUri } })} disabled={pLoading} />
+      </View>
+      <SectionList
+        sections={sections}
+        renderItem={renderChange}
+        renderSectionHeader={({ section }) => <Text style={styles.sectionHeader}>{section.title} ({section.data.length})</Text>}
+        keyExtractor={(item) => item.key}
+        onRefresh={refetch}
+        refreshing={loading}
+      />
+      <Button title="Commit Staged" onPress={() => setCommitModalVisible(true)} disabled={!data?.gitStatus.staged.length} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-    container: { flex: 1, padding: 16, gap: 8 },
-    branch: { fontWeight: 'bold', fontSize: 16 },
-    header: { fontWeight: 'bold' },
-    change: { fontFamily: 'monospace', paddingVertical: 2 },
-    actions: { marginTop: 'auto', gap: 8 }
+  container: { flex: 1, padding: 16 },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
+  sectionHeader: { fontWeight: 'bold', marginTop: 8 },
+  changeItem: { flexDirection: 'row', alignItems: 'center', paddingVertical: 4, marginBottom: 8 },
+  path: { flex: 1, fontFamily: 'monospace' },
+  modalContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' },
+  modalView: { backgroundColor: 'white', padding: 16, width: '80%', borderRadius: 4 },
+  commitInput: { borderWidth: 1, borderColor: '#ccc', marginBottom: 8, padding: 8, minHeight: 60 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 });

--- a/apps/mobile/src/state/debugStore.ts
+++ b/apps/mobile/src/state/debugStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface DebugState {
+  logs: string[];
+  isActive: boolean;
+  appendLog: (log: string) => void;
+  setActive: (active: boolean) => void;
+  clearLogs: () => void;
+}
+
+export const useDebugStore = create<DebugState>((set) => ({
+  logs: [],
+  isActive: false,
+  appendLog: (log) => set((s) => ({ logs: [...s.logs, log] })),
+  setActive: (active) => set({ isActive: active }),
+  clearLogs: () => set({ logs: [] }),
+}));

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "eslint": "^8.42.0",
+    "graphql": "^16.11.0",
     "typescript": "^5.1.3",
     "vsce": "^2.15.0"
+  },
+  "resolutions": {
+    "typescript": "5.1.3"
   }
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -8,7 +8,13 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-webview": "*"
+  },
+  "devDependencies": {
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "react-native-webview": "11.26.0"
   },
   "scripts": {
     "test": "echo 'no tests'"

--- a/packages/react-native-monaco-editor/src/editor-html.ts
+++ b/packages/react-native-monaco-editor/src/editor-html.ts
@@ -1,8 +1,8 @@
-export const editorHtml = (
+export function editorHtml(
   initialValue: string,
-  language: string,
-  extraScript = ''
-) => `
+  language: string
+): string {
+  return `
 <!DOCTYPE html>
 <html>
 <head>
@@ -74,9 +74,9 @@ export const editorHtml = (
             window.editor = editor;
             window.monaco = monaco;
         });
-        ${extraScript}
     </script>
 </body>
 </html>
 `;
+}
 

--- a/packages/react-native-monaco-editor/src/index.tsx
+++ b/packages/react-native-monaco-editor/src/index.tsx
@@ -5,15 +5,20 @@ import { editorHtml } from './editor-html';
 
 export interface MonacoEditorRef {
   revealLineInCenter: (lineNumber: number, scroll?: number) => void;
-  getEditor: () => any;
+  getEditor: () => unknown;
+}
+
+export interface CursorPosition {
+  lineNumber: number;
+  column: number;
 }
 
 export interface MonacoEditorProps {
   doc: Y.Text;
   language?: string;
   onContentChange?: (content: string) => void;
-  onCursorChange?: (position: any) => void;
-  remoteCursors?: { position: any; color: string; name: string }[];
+  onCursorChange?: (position: CursorPosition) => void;
+  remoteCursors?: { position: CursorPosition; color: string; name: string }[];
   style?: object;
   onLoad?: () => void;
 }
@@ -21,9 +26,12 @@ export interface MonacoEditorProps {
 const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
   ({ doc, language = 'plaintext', onContentChange, onCursorChange, remoteCursors, style, onLoad }, ref) => {
     const webviewRef = useRef<WebView>(null);
-    const editorRef = useRef<any>(null);
+    const editorRef = useRef<unknown>(null);
 
-    const initialText = useMemo(() => doc.toString().replace(/`/g, '\\`'), [doc]);
+    const initialText = useMemo(() => {
+      const str = doc.toString();
+      return JSON.stringify(str).slice(1, -1);
+    }, [doc]);
     const htmlContent = useMemo(() => editorHtml(initialText, language), [initialText, language]);
 
     useImperativeHandle(ref, () => ({
@@ -36,17 +44,34 @@ const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
 
     const handleMessage = (event: WebViewMessageEvent) => {
       try {
-        const message = JSON.parse(event.nativeEvent.data);
+        let message: { type: string; payload: unknown };
+        try {
+          message = JSON.parse(event.nativeEvent.data);
+        } catch (error) {
+          console.warn('Failed to parse WebView message:', error);
+          return;
+        }
         switch (message.type) {
           case 'editorDidMount':
             editorRef.current = message.payload;
             onLoad?.();
             break;
-          case 'contentDidChange':
-            onContentChange?.(message.payload.value);
+          case 'contentDidChange': {
+            const payload = message.payload;
+            if (
+              payload &&
+              typeof payload === 'object' &&
+              'value' in payload &&
+              typeof (payload as Record<string, unknown>).value === 'string'
+            ) {
+              onContentChange?.((payload as { value: string }).value);
+            } else {
+              console.warn('Invalid payload for contentDidChange:', payload);
+            }
             break;
+          }
           case 'cursorDidChange':
-            onCursorChange?.(message.payload.position);
+            onCursorChange?.((message.payload as { position: CursorPosition }).position);
             break;
           default:
             console.warn(`Unknown message type from WebView: ${message.type}`);
@@ -58,7 +83,23 @@ const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
 
     useEffect(() => {
       if (remoteCursors && remoteCursors.length > 0) {
-        const script = `\n                const decorations = ${JSON.stringify(remoteCursors)}.map(cursor => ({\n                    range: new monaco.Range(cursor.position.lineNumber, cursor.position.column, cursor.position.lineNumber, cursor.position.column),\n                    options: {\n                        className: 'remote-cursor',\n                        stickiness: 1,\n                        afterContentClassName: 'remote-cursor-label',\n                        after: { content: \`${cursor.name}\` }\n                    }\n                }));\n                editor.deltaDecorations([], decorations);\n            `;
+        const safeCursors = remoteCursors.map(c => ({
+          position: c.position,
+          color: c.color,
+          name: JSON.stringify(c.name).slice(1, -1),
+        }));
+        const script = `
+                const decorations = ${JSON.stringify(safeCursors)}.map(cursor => ({
+                    range: new monaco.Range(cursor.position.lineNumber, cursor.position.column, cursor.position.lineNumber, cursor.position.column),
+                    options: {
+                        className: 'remote-cursor',
+                        stickiness: 1,
+                        afterContentClassName: 'remote-cursor-label',
+                        after: { content: \`${'$'}{cursor.name}\` }
+                    }
+                }));
+                editor.deltaDecorations([], decorations);
+            `;
         webviewRef.current?.injectJavaScript(script);
       }
     }, [remoteCursors]);
@@ -79,4 +120,3 @@ const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
 );
 
 export default MonacoEditor;
-

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src']
-};

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,13 +3,9 @@
   "version": "1.0.0",
   "main": "src/index.js",
   "scripts": {
-    "test": "jest --passWithNoTests"
+    "test": "echo 'no tests'"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.2",
-    "graphql": "^16.6.0",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.1.0",
     "typescript": "^5.1.3"
   }
 }

--- a/packages/shared/src/operations.ts
+++ b/packages/shared/src/operations.ts
@@ -41,7 +41,8 @@ gql`
   query GitStatus($workspaceUri: String!) {
     gitStatus(workspaceUri: $workspaceUri) {
       branch
-      changes
+      staged
+      unstaged
     }
   }
 `;
@@ -53,6 +54,55 @@ gql`
       name
       description
       installed
+    }
+  }
+`;
+
+gql`
+  query GitDiff($workspaceUri: String!, $file: String!) {
+    gitDiff(workspaceUri: $workspaceUri, file: $file)
+  }
+`;
+
+gql`
+  mutation GitStage($workspaceUri: String!, $file: String!) {
+    gitStage(workspaceUri: $workspaceUri, file: $file)
+  }
+`;
+
+gql`
+  mutation GitUnstage($workspaceUri: String!, $file: String!) {
+    gitUnstage(workspaceUri: $workspaceUri, file: $file)
+  }
+`;
+
+gql`
+  query GetLaunchConfigurations($workspaceUri: String!) {
+    getLaunchConfigurations(workspaceUri: $workspaceUri) {
+      name
+      type
+      request
+    }
+  }
+`;
+
+gql`
+  mutation StartDebugging($workspaceUri: String!, $configName: String!) {
+    startDebugging(workspaceUri: $workspaceUri, configName: $configName)
+  }
+`;
+
+gql`
+  mutation StopDebugging {
+    stopDebugging
+  }
+`;
+
+gql`
+  subscription DebuggerEvent {
+    debuggerEvent {
+      event
+      body
     }
   }
 `;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -12,6 +12,19 @@ export type Scalars = {
   Float: number;
 };
 
+export type DebugConfiguration = {
+  __typename?: 'DebugConfiguration';
+  name: Scalars['String'];
+  request: Scalars['String'];
+  type: Scalars['String'];
+};
+
+export type DebuggerEvent = {
+  __typename?: 'DebuggerEvent';
+  body: Scalars['String'];
+  event: Scalars['String'];
+};
+
 export type Extension = {
   __typename?: 'Extension';
   description: Scalars['String'];
@@ -36,15 +49,20 @@ export type File = {
 export type GitStatus = {
   __typename?: 'GitStatus';
   branch: Scalars['String'];
-  changes: Array<Scalars['String']>;
+  staged: Array<Scalars['String']>;
+  unstaged: Array<Scalars['String']>;
 };
 
 export type Mutation = {
   __typename?: 'Mutation';
   commit: Scalars['Boolean'];
+  gitStage: Scalars['Boolean'];
+  gitUnstage: Scalars['Boolean'];
   installExtension: Scalars['Boolean'];
   pairWithServer?: Maybe<Scalars['String']>;
   push: Scalars['Boolean'];
+  startDebugging: Scalars['Boolean'];
+  stopDebugging: Scalars['Boolean'];
   uninstallExtension: Scalars['Boolean'];
   writeFile: Scalars['Boolean'];
 };
@@ -52,6 +70,18 @@ export type Mutation = {
 
 export type MutationCommitArgs = {
   message: Scalars['String'];
+  workspaceUri: Scalars['String'];
+};
+
+
+export type MutationGitStageArgs = {
+  file: Scalars['String'];
+  workspaceUri: Scalars['String'];
+};
+
+
+export type MutationGitUnstageArgs = {
+  file: Scalars['String'];
   workspaceUri: Scalars['String'];
 };
 
@@ -71,6 +101,12 @@ export type MutationPushArgs = {
 };
 
 
+export type MutationStartDebuggingArgs = {
+  configName: Scalars['String'];
+  workspaceUri: Scalars['String'];
+};
+
+
 export type MutationUninstallExtensionArgs = {
   id: Scalars['String'];
 };
@@ -85,11 +121,24 @@ export type MutationWriteFileArgs = {
 export type Query = {
   __typename?: 'Query';
   extensions: Array<Extension>;
+  getLaunchConfigurations: Array<DebugConfiguration>;
+  gitDiff: Scalars['String'];
   gitStatus: GitStatus;
   listDirectory: Array<File>;
   listWorkspaces: Array<Workspace>;
   readFile?: Maybe<Scalars['String']>;
   search: Array<SearchResult>;
+};
+
+
+export type QueryGetLaunchConfigurationsArgs = {
+  workspaceUri: Scalars['String'];
+};
+
+
+export type QueryGitDiffArgs = {
+  file: Scalars['String'];
+  workspaceUri: Scalars['String'];
 };
 
 
@@ -124,6 +173,7 @@ export type SearchResult = {
 
 export type Subscription = {
   __typename?: 'Subscription';
+  debuggerEvent: DebuggerEvent;
   fsEvent: FsEvent;
 };
 
@@ -167,12 +217,61 @@ export type GitStatusQueryVariables = Exact<{
 }>;
 
 
-export type GitStatusQuery = { __typename?: 'Query', gitStatus: { __typename?: 'GitStatus', branch: string, changes: Array<string> } };
+export type GitStatusQuery = { __typename?: 'Query', gitStatus: { __typename?: 'GitStatus', branch: string, staged: Array<string>, unstaged: Array<string> } };
 
 export type ExtensionsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type ExtensionsQuery = { __typename?: 'Query', extensions: Array<{ __typename?: 'Extension', id: string, name: string, description: string, installed: boolean }> };
+
+export type GitDiffQueryVariables = Exact<{
+  workspaceUri: Scalars['String'];
+  file: Scalars['String'];
+}>;
+
+
+export type GitDiffQuery = { __typename?: 'Query', gitDiff: string };
+
+export type GitStageMutationVariables = Exact<{
+  workspaceUri: Scalars['String'];
+  file: Scalars['String'];
+}>;
+
+
+export type GitStageMutation = { __typename?: 'Mutation', gitStage: boolean };
+
+export type GitUnstageMutationVariables = Exact<{
+  workspaceUri: Scalars['String'];
+  file: Scalars['String'];
+}>;
+
+
+export type GitUnstageMutation = { __typename?: 'Mutation', gitUnstage: boolean };
+
+export type GetLaunchConfigurationsQueryVariables = Exact<{
+  workspaceUri: Scalars['String'];
+}>;
+
+
+export type GetLaunchConfigurationsQuery = { __typename?: 'Query', getLaunchConfigurations: Array<{ __typename?: 'DebugConfiguration', name: string, type: string, request: string }> };
+
+export type StartDebuggingMutationVariables = Exact<{
+  workspaceUri: Scalars['String'];
+  configName: Scalars['String'];
+}>;
+
+
+export type StartDebuggingMutation = { __typename?: 'Mutation', startDebugging: boolean };
+
+export type StopDebuggingMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type StopDebuggingMutation = { __typename?: 'Mutation', stopDebugging: boolean };
+
+export type DebuggerEventSubscriptionVariables = Exact<{ [key: string]: never; }>;
+
+
+export type DebuggerEventSubscription = { __typename?: 'Subscription', debuggerEvent: { __typename?: 'DebuggerEvent', event: string, body: string } };
 
 export type PairWithServerMutationVariables = Exact<{
   pairingToken: Scalars['String'];

--- a/src/core/bus.ts
+++ b/src/core/bus.ts
@@ -7,33 +7,38 @@ import {
 } from './types'
 
 export class InMemoryBus<IM extends IntentMap>
-  implements PluginBus<IM, PluginContext<IM>>
+  implements PluginBus<IM>
 {
   private readonly emitter = new EventEmitter()
 
-  emit<K extends keyof IM>(intent: K, payload: IM[K]): void {
-    this.emitter.emit(intent as string, payload)
+  async emit<K extends keyof IM>(intent: K, payload: IM[K]): Promise<CRDTResult[]> {
+    const listeners = this.emitter.listeners(intent as string) as ((payload: IM[K]) => CRDTResult | Promise<CRDTResult>)[]
+    const results = await Promise.all(listeners.map(fn => Promise.resolve(fn(payload))) )
+    return results
   }
 
-  on<K extends keyof IM>(intent: K, cb: (payload: IM[K]) => void): void {
+  on<K extends keyof IM>(intent: K, cb: (payload: IM[K]) => CRDTResult | Promise<CRDTResult>): void {
     this.emitter.on(intent as string, cb as (payload: unknown) => void)
+  }
+
+  listeners<K extends keyof IM>(intent: K) {
+    return this.emitter.listeners(intent as string) as ((payload: IM[K]) => CRDTResult | Promise<CRDTResult>)[]
   }
 }
 
 export class BasicPluginContext<IM extends IntentMap>
   implements PluginContext<IM>
 {
-  constructor(readonly id: string, private readonly bus: PluginBus<IM, PluginContext<IM>>) {}
+  constructor(readonly id: string, private readonly bus: PluginBus<IM>) {}
 
   on<K extends keyof IM>(
     intent: K,
     cb: (payload: IM[K]) => CRDTResult | Promise<CRDTResult>,
   ): void {
-    this.bus.on(intent, cb as (payload: IM[K]) => void)
+    this.bus.on(intent, cb)
   }
 
-  intent<K extends keyof IM>(intent: K, payload: IM[K]): Promise<CRDTResult> {
-    this.bus.emit(intent, payload)
-    return Promise.resolve({ success: true })
+  intent<K extends keyof IM>(intent: K, payload: IM[K]): Promise<CRDTResult[]> {
+    return this.bus.emit(intent, payload)
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -30,16 +30,16 @@ export interface PluginContext<IM extends IntentMap> {
   intent<K extends keyof IM>(
     intent: K,
     payload: IM[K],
-  ): Promise<CRDTResult>
+  ): Promise<CRDTResult[]>
 }
 
 /** The bus your plugin uses to emit & listen */
 export interface PluginBus<
-  IM extends IntentMap,
-  CTX extends PluginContext<IM>
+  IM extends IntentMap
 > {
-  emit<K extends keyof IM>(intent: K, payload: IM[K]): void
-  on<K extends keyof IM>(intent: K, cb: (payload: IM[K]) => void): void
+  emit<K extends keyof IM>(intent: K, payload: IM[K]): Promise<CRDTResult[]>
+  on<K extends keyof IM>(intent: K, cb: (payload: IM[K]) => CRDTResult | Promise<CRDTResult>): void
+  listeners?<K extends keyof IM>(intent: K): ((payload: IM[K]) => CRDTResult | Promise<CRDTResult>)[]
 }
 
 /** The core Plugin interface */

--- a/src/plugins/MyPlugin.ts
+++ b/src/plugins/MyPlugin.ts
@@ -20,7 +20,7 @@ export class MyPlugin implements Plugin<MyIntents, PluginContext<MyIntents>> {
   private nodes = new Map<string, { name: string }>()
 
   constructor(
-    private readonly bus: PluginBus<MyIntents, PluginContext<MyIntents>>,
+    private readonly bus: PluginBus<MyIntents>,
   ) {
     this.id = 'my-plugin'
   }
@@ -48,5 +48,4 @@ export class MyPlugin implements Plugin<MyIntents, PluginContext<MyIntents>> {
 }
 
 /** Export a factory so consumers get a real instance */
-export default (bus: PluginBus<MyIntents, PluginContext<MyIntents>>) =>
-  new MyPlugin(bus)
+export default (bus: PluginBus<MyIntents>) => new MyPlugin(bus)

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.14.0, @babel/core@npm:^7.20.0, @babel/core@npm:^7.23.9":
+"@babel/core@npm:*, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.14.0, @babel/core@npm:^7.20.0, @babel/core@npm:^7.23.9, @babel/core@npm:^7.28.0":
   version: 7.28.0
   resolution: "@babel/core@npm:7.28.0"
   dependencies:
@@ -1667,7 +1667,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.20.0":
+"@babel/preset-env@npm:*, @babel/preset-env@npm:^7.20.0":
   version: 7.28.0
   resolution: "@babel/preset-env@npm:7.28.0"
   dependencies:
@@ -3052,6 +3052,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/pattern@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/pattern@npm:30.0.1"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-regex-util: "npm:30.0.1"
+  checksum: 10c0/32c5a7bfb6c591f004dac0ed36d645002ed168971e4c89bd915d1577031672870032594767557b855c5bc330aa1e39a2f54bf150d2ee88a7a0886e9cb65318bc
+  languageName: node
+  linkType: hard
+
 "@jest/reporters@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/reporters@npm:29.7.0"
@@ -3086,6 +3096,15 @@ __metadata:
     node-notifier:
       optional: true
   checksum: 10c0/a754402a799541c6e5aff2c8160562525e2a47e7d568f01ebfc4da66522de39cbb809bbb0a841c7052e4270d79214e70aec3c169e4eae42a03bc1a8a20cb9fa2
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/schemas@npm:30.0.1"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10c0/27977359edc4b33293af7c85c53de5014a87c29b9ab98b0a827fedfc6635abdb522aad8c3ff276080080911f519699b094bd6f4e151b43f0cc5856ccc83c04a7
   languageName: node
   linkType: hard
 
@@ -3153,6 +3172,21 @@ __metadata:
     slash: "npm:^3.0.0"
     write-file-atomic: "npm:^4.0.2"
   checksum: 10c0/7f4a7f73dcf45dfdf280c7aa283cbac7b6e5a904813c3a93ead7e55873761fc20d5c4f0191d2019004fac6f55f061c82eb3249c2901164ad80e362e7a7ede5a6
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/types@npm:30.0.1"
+  dependencies:
+    "@jest/pattern": "npm:30.0.1"
+    "@jest/schemas": "npm:30.0.1"
+    "@types/istanbul-lib-coverage": "npm:^2.0.6"
+    "@types/istanbul-reports": "npm:^3.0.4"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.33"
+    chalk: "npm:^4.1.2"
+  checksum: 10c0/407469331e74f9bb1ffd40202c3a8cece2fd07ba535adeb60557bdcee13713cf2f14cf78869ba7ef50a7e6fe0ed7cc97ec775056dd640fc0a332e8fbfaec1ee8
   languageName: node
   linkType: hard
 
@@ -3800,6 +3834,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-picker/picker@npm:^2.4.10":
+  version: 2.11.1
+  resolution: "@react-native-picker/picker@npm:2.11.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/d2e9aeb32ae80f2ab56fa025f1afd6d8ff8051e7078bfd17c6794ff0cc1538d4a2f548098826eb652e6cb64d998070b0111777c78de4dcb468cb71e7e4d93097
+  languageName: node
+  linkType: hard
+
 "@react-native/assets@npm:1.0.0":
   version: 1.0.0
   resolution: "@react-native/assets@npm:1.0.0"
@@ -3957,6 +4001,13 @@ __metadata:
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
   checksum: 10c0/ef6351ae073c45c2ac89494dbb3e1f87cc60a93ce4cde797b782812b6f97da0d620ae81973f104b43c9b7eaa789ad20ba4f6a1359f1cc62f63729a55a7d22d4e
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.34.0":
+  version: 0.34.37
+  resolution: "@sinclair/typebox@npm:0.34.37"
+  checksum: 10c0/22fff01853d8f35e8a1f0be004e91a0c3ced16f35b8d7e915392e91bf021190bcba45102cd148679c53440c4ed228b31d7a2635461ea5d089ef581f6254ecfb4
   languageName: node
   linkType: hard
 
@@ -4134,7 +4185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1, @types/istanbul-lib-coverage@npm:^2.0.6":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
   checksum: 10c0/3948088654f3eeb45363f1db158354fb013b362dba2a5c2c18c559484d5eb9f6fd85b23d66c0a7c2fcfab7308d0a585b14dadaca6cc8bf89ebfdc7f8f5102fb7
@@ -4150,7 +4201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-reports@npm:^3.0.0":
+"@types/istanbul-reports@npm:^3.0.0, @types/istanbul-reports@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/istanbul-reports@npm:3.0.4"
   dependencies:
@@ -4402,7 +4453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.8":
+"@types/yargs@npm:^17.0.33, @types/yargs@npm:^17.0.8":
   version: 17.0.33
   resolution: "@types/yargs@npm:17.0.33"
   dependencies:
@@ -5949,6 +6000,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ci-info@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "ci-info@npm:4.3.0"
+  checksum: 10c0/60d3dfe95d75c01454ec1cfd5108617dd598a28a2a3e148bd7e1523c1c208b5f5a3007cafcbe293e6fd0a5a310cc32217c5dc54743eeabc0a2bec80072fc055c
+  languageName: node
+  linkType: hard
+
 "cjs-module-lexer@npm:^1.0.0":
   version: 1.4.3
   resolution: "cjs-module-lexer@npm:1.4.3"
@@ -6961,10 +7019,14 @@ __metadata:
   resolution: "editor@workspace:packages/editor"
   dependencies:
     lodash.debounce: "npm:^4.0.8"
+    react: "npm:18.2.0"
+    react-native: "npm:0.71.8"
     react-native-monaco-editor: "npm:^0.1.0"
+    react-native-webview: "npm:11.26.0"
   peerDependencies:
     react: "*"
     react-native: "*"
+    react-native-webview: "*"
   languageName: unknown
   linkType: soft
 
@@ -8447,7 +8509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -8545,7 +8607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.6.0":
+"graphql@npm:^16.11.0, graphql@npm:^16.6.0":
   version: 16.11.0
   resolution: "graphql@npm:16.11.0"
   checksum: 10c0/124da7860a2292e9acf2fed0c71fc0f6a9b9ca865d390d112bdd563c1f474357141501c12891f4164fe984315764736ad67f705219c62f7580681d431a85db88
@@ -9916,6 +9978,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-regex-util@npm:30.0.1":
+  version: 30.0.1
+  resolution: "jest-regex-util@npm:30.0.1"
+  checksum: 10c0/f30c70524ebde2d1012afe5ffa5691d5d00f7d5ba9e43d588f6460ac6fe96f9e620f2f9b36a02d0d3e7e77bc8efb8b3450ae3b80ac53c8be5099e01bf54f6728
+  languageName: node
+  linkType: hard
+
 "jest-regex-util@npm:^27.0.6":
   version: 27.5.1
   resolution: "jest-regex-util@npm:27.5.1"
@@ -10068,7 +10137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.7.0":
+"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-util@npm:29.7.0"
   dependencies:
@@ -10079,6 +10148,20 @@ __metadata:
     graceful-fs: "npm:^4.2.9"
     picomatch: "npm:^2.2.3"
   checksum: 10c0/bc55a8f49fdbb8f51baf31d2a4f312fb66c9db1483b82f602c9c990e659cdd7ec529c8e916d5a89452ecbcfae4949b21b40a7a59d4ffc0cd813a973ab08c8150
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^30.0.2":
+  version: 30.0.2
+  resolution: "jest-util@npm:30.0.2"
+  dependencies:
+    "@jest/types": "npm:30.0.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^4.2.0"
+    graceful-fs: "npm:^4.2.11"
+    picomatch: "npm:^4.0.2"
+  checksum: 10c0/07de384790b8e5a5925fba5448fa1475790a5b52271fbf99958c18e468da1af940f8b45e330d87766576cf6c5d1f4f41ce51c976483a5079653d9fcdba8aac8e
   languageName: node
   linkType: hard
 
@@ -10973,6 +11056,13 @@ __metadata:
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
   checksum: 10c0/ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "lru-cache@npm:11.1.0"
+  checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
   languageName: node
   linkType: hard
 
@@ -11927,12 +12017,15 @@ __metadata:
     graphql-subscriptions: "npm:^2.0.0"
     graphql-ws: "npm:^5.11.0"
     jest: "npm:^29.5.0"
+    jest-util: "npm:^30.0.2"
     jsonwebtoken: "npm:^9.0.0"
+    lru-cache: "npm:^11.1.0"
     simple-git: "npm:^3.19.0"
     ts-jest: "npm:^29.1.0"
     typescript: "npm:^5.1.3"
     ws: "npm:^8.12.0"
     y-websocket: "npm:^1.5.0"
+    yjs: "npm:^13.5.43"
   languageName: unknown
   linkType: soft
 
@@ -11946,6 +12039,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.59.8"
     "@typescript-eslint/parser": "npm:^5.59.8"
     eslint: "npm:^8.42.0"
+    graphql: "npm:^16.11.0"
     typescript: "npm:^5.1.3"
     vsce: "npm:^2.15.0"
   languageName: unknown
@@ -11958,6 +12052,7 @@ __metadata:
     "@apollo/client": "npm:^3.8.0"
     "@babel/core": "npm:^7.20.0"
     "@react-native-async-storage/async-storage": "npm:^1.20.1"
+    "@react-native-picker/picker": "npm:^2.4.10"
     "@react-navigation/bottom-tabs": "npm:^6.5.7"
     "@react-navigation/native": "npm:^6.1.6"
     "@react-navigation/native-stack": "npm:^6.9.12"
@@ -11974,6 +12069,7 @@ __metadata:
     react-native: "npm:0.71.8"
     react-native-monaco-editor: "npm:^0.1.0"
     react-native-safe-area-context: "npm:4.5.0"
+    react-native-screens: "npm:^3.20.0"
     react-native-url-polyfill: "npm:^1.3.0"
     react-native-vector-icons: "npm:^9.2.0"
     react-native-webview: "npm:11.26.0"
@@ -13236,6 +13332,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-freeze@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "react-freeze@npm:1.0.4"
+  peerDependencies:
+    react: ">=17.0.0"
+  checksum: 10c0/8f51257c261bfefff86f618e958683536248f708019632d309ee5ebdd52f25d3c130660d06fb6f0f4fdef79f00f8ec7177233a872c2321f7d46b7e77ccc522a1
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.0.0, react-is@npm:^18.2.0":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
@@ -13293,6 +13398,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/cd9dfe25803b7b120940c243d9c9f10b0b61d262ad5875245909cdbf0025684241189b2796d35028519fee0e7a94e6f47bcaf2e23fc7801875d5f633a7778296
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:^3.20.0":
+  version: 3.37.0
+  resolution: "react-native-screens@npm:3.37.0"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/a8de8dc21f522567de1600ae79a5ec472ffe3db8bc90d4ca8b58deae6e732e35d090a52f26cbc7591d635385f83b2784382d543dbb8d2b5fe40ed1f7bffe940b
   languageName: node
   linkType: hard
 
@@ -14150,10 +14268,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "shared@workspace:packages/shared"
   dependencies:
-    "@types/jest": "npm:^29.5.2"
-    graphql: "npm:^16.6.0"
-    jest: "npm:^29.5.0"
-    ts-jest: "npm:^29.1.0"
     typescript: "npm:^5.1.3"
   languageName: unknown
   linkType: soft
@@ -15430,23 +15544,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.1.3":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
+"typescript@npm:5.1.3":
+  version: 5.1.3
+  resolution: "typescript@npm:5.1.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
+  checksum: 10c0/1faba8d5ffd4717864ddce767613c5ab77c1c8510c1ce21dc9b112a4c662357b9338dc0a6121615266d3a44ebec699f115ef2dabf18d9d7341ea1675692b9b24
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.1.3#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A5.1.3#optional!builtin<compat/typescript>":
+  version: 5.1.3
+  resolution: "typescript@patch:typescript@npm%3A5.1.3#optional!builtin<compat/typescript>::version=5.1.3&hash=5da071"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  checksum: 10c0/769c5a11a9d5207ae5ce4c84b5c7a72ad92a28877a0061881ccfb326a43a1a1de79c4daff2f9d74720137744cfc9332fddbfbc4c3973c1e859b2f977f5d11b72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- refine `stopDebugging` to return the real result from VS Code
- escape initial document text using `JSON.stringify`
- update generated types and reinstall
- remove unused jest-util dependency
- memoize debug controls
- keep CRDT cache entries fresh and escape remote cursor names
- set platform-appropriate font for diff modal
- return results from plugin bus

## Testing
- `yarn install`
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6874853e356083339e12b28f01609809