### PR TITLE
Fix server test setup and persistence

### DIFF
--- a/apps/backend/__mocks__/vscode.ts
+++ b/apps/backend/__mocks__/vscode.ts
@@ -1,0 +1,40 @@
+const workspace = {
+    getConfiguration: jest.fn(() => ({ get: jest.fn() })),
+    fs: {
+        readDirectory: jest.fn(),
+        readFile: jest.fn(),
+        writeFile: jest.fn(),
+    },
+    getWorkspaceFolder: jest.fn(),
+    asRelativePath: jest.fn(),
+    createFileSystemWatcher: jest.fn(),
+    workspaceFolders: [] as any,
+};
+
+const vscodeWindow = {
+    showWarningMessage: jest.fn(),
+    showErrorMessage: jest.fn(),
+    showInformationMessage: jest.fn(),
+};
+
+const debug = {
+    onDidStartDebugSession: jest.fn(),
+    onDidTerminateDebugSession: jest.fn(),
+    onDidReceiveDebugSessionCustomEvent: jest.fn(),
+    startDebugging: jest.fn(),
+    stopDebugging: jest.fn(),
+};
+
+const Uri = {
+    parse: (s: string) => ({ fsPath: s.replace('file://', ''), toString: () => s }),
+    file: (p: string) => ({ fsPath: p, toString: () => `file://${p}` }),
+};
+
+const FileType = { Directory: 2 };
+
+class RelativePattern {
+    base: any; pattern: string;
+    constructor(base: any, pattern: string) { this.base = base; this.pattern = pattern; }
+}
+
+module.exports = { workspace, window: vscodeWindow, debug, Uri, FileType, RelativePattern };

--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src']
+  moduleNameMapper: {
+    '^vscode$': '<rootDir>/__mocks__/vscode.ts',
+  },
 };

--- a/apps/backend/src/constants.ts
+++ b/apps/backend/src/constants.ts
@@ -1,0 +1,2 @@
+export const FS_EVENT = 'FS_EVENT';
+export const DEBUG_EVENT = 'DEBUG_EVENT';

--- a/apps/backend/src/core/server.test.ts
+++ b/apps/backend/src/core/server.test.ts
@@ -6,25 +6,22 @@ import { initializeFileSystemWatcher, disposeFileSystemWatcher } from '../watche
 jest.mock('./auth');
 jest.mock('../watchers/fileSystemWatcher');
 
+// Use inline mocks to avoid circular dependency issues with ts-jest and virtual mocks
 const listen = jest.fn((port: number, cb: () => void) => cb());
 const close = jest.fn((cb: () => void) => cb());
 const on = jest.fn();
-
 jest.mock('https', () => ({
-    createServer: jest.fn(() => ({ listen, close, on }))
-}), { virtual: true });
+    createServer: jest.fn(() => ({ listen, close, on })),
+}));
 
 jest.mock('express', () => {
     const use = jest.fn();
     const json = jest.fn(() => 'json');
-    const expressMock: any = jest.fn(() => ({ use }));
-    expressMock.json = json;
-    return Object.assign(expressMock, { __mocks: { use, json, expressMock } });
-}, { virtual: true });
-const expressModule = jest.requireMock('express').__mocks;
-const use = expressModule.use as jest.Mock;
-const json = expressModule.json as jest.Mock;
-const expressMock = expressModule.expressMock as jest.Mock;
+    const expressMock = jest.fn(() => ({ use }));
+    (expressMock as any).json = json;
+    return expressMock;
+});
+const expressMock = jest.requireMock('express') as jest.Mock;
 
 const start = jest.fn(() => Promise.resolve());
 const applyMiddleware = jest.fn();
@@ -34,55 +31,32 @@ class FakeApolloServer {
     applyMiddleware = applyMiddleware;
     stop = stop;
 }
-jest.mock('apollo-server-express', () => ({
-    ApolloServer: jest.fn(() => new FakeApolloServer()),
-    gql: (literals: any, ...placeholders: any[]) => literals.reduce((acc: string, lit: string, i: number) => acc + placeholders[i - 1] + lit)
-}), { virtual: true });
-
-jest.mock('@graphql-tools/schema', () => ({ makeExecutableSchema: jest.fn(() => 'schema') }), { virtual: true });
-
-const ws = { on: jest.fn(), handleUpgrade: jest.fn(), close: jest.fn() };
-jest.mock('ws', () => ({ WebSocketServer: jest.fn(() => ws) }), { virtual: true });
-
-jest.mock('graphql-ws/lib/use/ws', () => ({ useServer: jest.fn(() => ({ dispose: jest.fn() })) }), { virtual: true });
-
+jest.mock('apollo-server-express', () => ({ ApolloServer: jest.fn(() => new FakeApolloServer()) }));
+jest.mock('@graphql-tools/schema', () => ({ makeExecutableSchema: jest.fn(() => 'schema') }));
+jest.mock('../schema', () => 'type Query { _: Boolean }', { virtual: true });
+jest.mock('ws', () => ({ WebSocketServer: jest.fn(() => ({ on: jest.fn(), handleUpgrade: jest.fn(), close: jest.fn() })) }));
+jest.mock('graphql-ws/lib/use/ws', () => ({ useServer: jest.fn(() => ({ dispose: jest.fn() })) }));
 jest.mock('y-websocket/bin/utils.js', () => ({ setupWSConnection: jest.fn(), setPersistence: jest.fn() }), { virtual: true });
-
 jest.mock('yjs', () => ({}), { virtual: true });
 jest.mock('lodash.debounce', () => () => undefined, { virtual: true });
-
 jest.mock('fs', () => ({
     existsSync: jest.fn(() => true),
-    readFileSync: jest.fn(() => Buffer.from('data'))
-}), { virtual: true });
-
-jest.mock('../graphql/resolvers', () => ({ getResolvers: jest.fn(() => ({})) }), { virtual: true });
-
-jest.mock('../ui/statusBar', () => ({ updateStatusBar: jest.fn() }), { virtual: true });
-
-jest.mock('path', () => ({ join: (...parts: string[]) => parts.join('/') }), { virtual: true });
-
-jest.mock('vscode', () => ({
-    workspace: {
-        getConfiguration: jest.fn(() => ({ get: jest.fn(() => 4000) }))
-    },
-    window: {
-        showWarningMessage: jest.fn(),
-        showErrorMessage: jest.fn(),
-        showInformationMessage: jest.fn()
-    }
-}), { virtual: true });
+    readFileSync: jest.fn(() => Buffer.from('data')),
+}));
+jest.mock('../graphql/resolvers', () => ({ getResolvers: jest.fn(() => ({})) }));
+jest.mock('../ui/statusBar', () => ({ updateStatusBar: jest.fn() }));
+jest.mock('path', () => ({ join: (...parts: string[]) => parts.join('/') }));
 
 describe('server start/stop', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         (ensureAuthContext as jest.Mock).mockResolvedValue({ jwtSecret: 'a', pairingToken: 'b', isPaired: false });
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({ get: jest.fn(() => 4000) });
     });
 
     it('starts and stops server', async () => {
         const context = { extensionPath: '/ext' } as vscode.ExtensionContext;
         await startServer(context);
-        await Promise.resolve();
         expect(expressMock).toHaveBeenCalled();
         expect(start).toHaveBeenCalled();
         expect(listen).toHaveBeenCalledWith(4000, expect.any(Function));
@@ -96,7 +70,6 @@ describe('server start/stop', () => {
     it('warns when already running', async () => {
         const context = { extensionPath: '/ext' } as vscode.ExtensionContext;
         await startServer(context);
-        await Promise.resolve();
         await startServer(context);
         expect(vscode.window.showWarningMessage).toHaveBeenCalled();
     });

--- a/apps/backend/src/core/server.ts
+++ b/apps/backend/src/core/server.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as https from 'https';
 import * as fs from 'fs';
+import { AddressInfo } from 'net';
 import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import { makeExecutableSchema } from '@graphql-tools/schema';
@@ -33,7 +34,7 @@ export async function startServer(context: vscode.ExtensionContext) {
 
     const app = express();
     app.use(express.json());
-    
+
     const keyPath = join(context.extensionPath, 'certs/server.key');
     const certPath = join(context.extensionPath, 'certs/server.crt');
     if (!fs.existsSync(keyPath) || !fs.existsSync(certPath)) {
@@ -54,60 +55,63 @@ export async function startServer(context: vscode.ExtensionContext) {
         context: ({ req }) => ({ user: (req as RequestWithUser).user }),
     });
 
-    apolloServer.start().then(() => {
-        if (!apolloServer || !httpServer) return;
+    await apolloServer.start();
+    
+    if (!apolloServer || !httpServer) return;
 
-        apolloServer.applyMiddleware({ app, path: '/graphql' });
+    apolloServer.applyMiddleware({ app, path: '/graphql' });
 
-        const gqlWsServer = new WebSocketServer({ noServer: true });
-        const gqlWsServerHandler = useServer({ schema }, gqlWsServer);
+    const gqlWsServer = new WebSocketServer({ noServer: true });
+    const gqlWsServerHandler = useServer({ schema }, gqlWsServer);
 
-        const yjsWsServer = new WebSocketServer({ noServer: true });
+    const yjsWsServer = new WebSocketServer({ noServer: true });
 
-        setPersistence({
-            bindState: (docName: string, ydoc: Doc) => {
-                bindState(docName, ydoc);
-            },
-            writeState: () => {
-                // Persistence is handled by debounced savers in bindState
-            },
-            provider: null,
-        });
-
-        yjsWsServer.on('connection', setupWSConnection);
-
-        httpServer.on('upgrade', (req, socket, head) => {
-            if (!req.url) {
-                socket.destroy();
-                return;
-            }
-            const host = req.headers.host || 'localhost:3000';
-            const protocol = 'https'; // Server uses HTTPS certificates
-            const url = new URL(req.url, `${protocol}://${host}`);
-            if (url.pathname === '/graphql') {
-                gqlWsServer.handleUpgrade(req, socket, head, ws => gqlWsServer.emit('connection', ws, req));
-            } else if (url.pathname.startsWith('/yjs')) {
-                yjsWsServer.handleUpgrade(req, socket, head, ws => yjsWsServer.emit('connection', ws, req));
-            } else {
-                socket.destroy();
-            }
-        });
-        
-        wsServerCleanup = () => {
-             gqlWsServerHandler.dispose();
-             yjsWsServer.close();
-             gqlWsServer.close();
-        };
-
-        const config = vscode.workspace.getConfiguration('mobile-vscode-server');
-        const port = config.get<number>('port', 4000);
-
-        httpServer.listen(port, () => {
-            console.log(`🚀 MobileVSCode Server ready at https://localhost:${port}`);
-        });
-
-        initializeFileSystemWatcher();
+    setPersistence({
+        bindState: (docName: string, ydoc: Doc) => {
+            bindState(docName, ydoc);
+        },
+        writeState: () => {
+            /* no-op */
+        },
+        provider: null,
     });
+
+    yjsWsServer.on('connection', setupWSConnection);
+
+    httpServer.on('upgrade', (req, socket, head) => {
+        if (!req.url) {
+            console.error('HTTP upgrade request missing URL. Destroying socket.');
+            socket.destroy();
+            return;
+        }
+        const host = req.headers.host || 'localhost:4000';
+        // Hardcode protocol to https as per review feedback for simplicity and robustness
+        const protocol = 'https'; 
+        const url = new URL(req.url, `${protocol}://${host}`);
+        
+        if (url.pathname === '/graphql') {
+            gqlWsServer.handleUpgrade(req, socket, head, ws => gqlWsServer.emit('connection', ws, req));
+        } else if (url.pathname.startsWith('/yjs')) {
+            yjsWsServer.handleUpgrade(req, socket, head, ws => yjsWsServer.emit('connection', ws, req));
+        } else {
+            socket.destroy();
+        }
+    });
+    
+    wsServerCleanup = () => {
+         gqlWsServerHandler.dispose();
+         yjsWsServer.close();
+         gqlWsServer.close();
+    };
+
+    const config = vscode.workspace.getConfiguration('mobile-vscode-server');
+    const port = config.get<number>('port', 4000);
+
+    httpServer.listen(port, () => {
+        console.log(`🚀 MobileVSCode Server ready at https://localhost:${port}`);
+    });
+
+    initializeFileSystemWatcher();
 }
 
 export function stopServer() {

--- a/apps/backend/src/providers/gitProvider.test.ts
+++ b/apps/backend/src/providers/gitProvider.test.ts
@@ -2,13 +2,6 @@ import { getGitProvider } from './gitProvider';
 import simpleGit from 'simple-git';
 import * as vscode from 'vscode';
 
-jest.mock('vscode', () => ({
-  workspace: {
-    getWorkspaceFolder: jest.fn(() => ({ uri: { fsPath: '/test' } })),
-  },
-  Uri: { parse: (s: string) => ({ fsPath: s.replace('file://', ''), toString: () => s }) },
-}), { virtual: true });
-
 jest.mock('simple-git');
 
 const mockGit = {
@@ -25,6 +18,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   (simpleGit as jest.Mock).mockReturnValue(mockGit);
   mockGit.checkIsRepo.mockResolvedValue(true);
+  (vscode.workspace.getWorkspaceFolder as jest.Mock).mockReturnValue({ uri: { fsPath: '/test' } });
 });
 
 describe('gitProvider', () => {
@@ -34,11 +28,13 @@ describe('gitProvider', () => {
   it('gitStatus returns correct status', async () => {
     mockGit.status.mockResolvedValue({
       current: 'main',
-      staged: ['a.txt'],
-      files: [{ path: 'a.txt' }, { path: 'b.txt' }],
+      files: [
+        { path: 'a.txt', index: 'A', working_dir: ' ' },
+        { path: 'b.txt', index: ' ', working_dir: 'M' },
+      ],
     });
 
-    const status = await provider.Query.gitStatus(null, args as any);
+    const status = await provider.Query.gitStatus(null, args);
     expect(status.branch).toBe('main');
     expect(status.staged).toEqual(['a.txt']);
     expect(status.unstaged).toEqual(['b.txt']);
@@ -46,23 +42,23 @@ describe('gitProvider', () => {
 
   it('gitDiff returns diff string', async () => {
     mockGit.diff.mockResolvedValue('diff');
-    const diff = await provider.Query.gitDiff(null, { ...args, file: 'file.txt' } as any);
+    const diff = await provider.Query.gitDiff(null, { ...args, file: 'file.txt' });
     expect(diff).toBe('diff');
     expect(mockGit.diff).toHaveBeenCalledWith(['file.txt']);
   });
 
   it('gitStage stages file', async () => {
-    await provider.Mutation.gitStage(null, { ...args, file: 'x' } as any);
+    await provider.Mutation.gitStage(null, { ...args, file: 'x' });
     expect(mockGit.add).toHaveBeenCalledWith('x');
   });
 
   it('gitUnstage unstages file', async () => {
-    await provider.Mutation.gitUnstage(null, { ...args, file: 'x' } as any);
+    await provider.Mutation.gitUnstage(null, { ...args, file: 'x' });
     expect(mockGit.reset).toHaveBeenCalledWith(['--', 'x']);
   });
 
   it('commit creates commit', async () => {
-    await provider.Mutation.commit(null, { ...args, message: 'm' } as any);
+    await provider.Mutation.commit(null, { ...args, message: 'm' });
     expect(mockGit.commit).toHaveBeenCalledWith('m');
   });
 });

--- a/apps/backend/src/providers/gitProvider.ts
+++ b/apps/backend/src/providers/gitProvider.ts
@@ -15,8 +15,8 @@ export const getGitProvider = () => ({
       const s = await git.status();
       return {
         branch: s.current || 'detached',
-        staged: s.staged,
-        unstaged: s.files.filter(f => !s.staged.includes(f.path)).map(f => f.path),
+        staged: s.files.filter(f => f.index.trim() !== '').map(f => f.path),
+        unstaged: s.files.filter(f => f.working_dir.trim() !== '').map(f => f.path),
       };
     },
     gitDiff: async (_: unknown, { workspaceUri, file }: { workspaceUri: string; file: string }) => {

--- a/apps/backend/src/watchers/fileSystemWatcher.test.ts
+++ b/apps/backend/src/watchers/fileSystemWatcher.test.ts
@@ -1,29 +1,18 @@
 import { initializeFileSystemWatcher, disposeFileSystemWatcher } from './fileSystemWatcher';
 import { pubsub } from '../graphql/pubsub';
+import { FS_EVENT } from '../constants';
 import * as vscode from 'vscode';
 
 type Callback = (uri: vscode.Uri) => void;
 
-const createFileSystemWatcher = jest.fn();
-const getWorkspaceFolder = jest.fn();
-const asRelativePath = jest.fn();
+const createFileSystemWatcher = vscode.workspace.createFileSystemWatcher as jest.Mock;
+const getWorkspaceFolder = vscode.workspace.getWorkspaceFolder as jest.Mock;
+const asRelativePath = vscode.workspace.asRelativePath as jest.Mock;
 
 let onCreate: Callback | undefined;
 let onChange: Callback | undefined;
 let onDelete: Callback | undefined;
 const dispose = jest.fn();
-
-jest.mock('vscode', () => ({
-    workspace: {
-        createFileSystemWatcher: (pattern: string) => createFileSystemWatcher(pattern),
-        getWorkspaceFolder: (uri: vscode.Uri) => getWorkspaceFolder(uri),
-        asRelativePath: (uri: vscode.Uri, _f?: boolean) => asRelativePath(uri),
-    },
-    Uri: {
-        file: (p: string) => ({ fsPath: p, toString: () => `file://${p}` })
-    },
-    FileType: { Directory: 2 }
-}), { virtual: true });
 
 jest.mock('../graphql/pubsub', () => ({
     pubsub: { publish: jest.fn() }
@@ -33,11 +22,17 @@ beforeEach(() => {
     (pubsub.publish as jest.Mock).mockClear();
     createFileSystemWatcher.mockImplementation(() => {
         return {
-            onDidCreate: (cb: Callback) => { onCreate = cb; },
-            onDidChange: (cb: Callback) => { onChange = cb; },
-            onDidDelete: (cb: Callback) => { onDelete = cb; },
-            dispose
-        } as any;
+            onDidCreate: (cb: Callback) => {
+                onCreate = cb;
+            },
+            onDidChange: (cb: Callback) => {
+                onChange = cb;
+            },
+            onDidDelete: (cb: Callback) => {
+                onDelete = cb;
+            },
+            dispose,
+        } as unknown as vscode.FileSystemWatcher;
     });
     getWorkspaceFolder.mockReturnValue({ uri: { fsPath: '/workspace/test' } });
     asRelativePath.mockImplementation((uri: vscode.Uri) => uri.fsPath.replace('/workspace/test/', ''));
@@ -51,13 +46,13 @@ it('publishes events for file changes', () => {
     initializeFileSystemWatcher();
     expect(createFileSystemWatcher).toHaveBeenCalledWith('**/*');
     const uri = { fsPath: '/workspace/test/foo.txt' } as vscode.Uri;
-    onCreate!(uri);
-    onChange!(uri);
-    onDelete!(uri);
+    onCreate?.(uri);
+    onChange?.(uri);
+    onDelete?.(uri);
     expect(pubsub.publish).toHaveBeenCalledTimes(3);
-    expect(pubsub.publish).toHaveBeenCalledWith('FS_EVENT', { fsEvent: { event: 'create', path: 'foo.txt' } });
-    expect(pubsub.publish).toHaveBeenCalledWith('FS_EVENT', { fsEvent: { event: 'change', path: 'foo.txt' } });
-    expect(pubsub.publish).toHaveBeenCalledWith('FS_EVENT', { fsEvent: { event: 'delete', path: 'foo.txt' } });
+    expect(pubsub.publish).toHaveBeenCalledWith(FS_EVENT, { fsEvent: { event: 'create', path: 'foo.txt' } });
+    expect(pubsub.publish).toHaveBeenCalledWith(FS_EVENT, { fsEvent: { event: 'change', path: 'foo.txt' } });
+    expect(pubsub.publish).toHaveBeenCalledWith(FS_EVENT, { fsEvent: { event: 'delete', path: 'foo.txt' } });
 });
 
 it('does not reinitialize watcher if already set', () => {
@@ -70,6 +65,5 @@ it('disposes watcher', () => {
     initializeFileSystemWatcher();
     disposeFileSystemWatcher();
     expect(dispose).toHaveBeenCalled();
-    // calling again should be safe
     disposeFileSystemWatcher();
 });

--- a/apps/mobile/src/screens/Debug.tsx
+++ b/apps/mobile/src/screens/Debug.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { View, Text, Button, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { useQuery, useMutation, useSubscription } from '@apollo/client';
+import { useErrorAlert } from '../hooks/useErrorAlert';
 import { GetLaunchConfigurationsDocument, StartDebuggingDocument, StopDebuggingDocument, DebuggerEventDocument } from 'shared/src/types';
 import { useDebugStore } from '../state/debugStore';
 
-export default function Debug({ route }) {
+export default function Debug({ route }: any) {
   const { workspaceUri } = route.params;
   const [selectedConfig, setSelectedConfig] = React.useState<string | null>(null);
 
@@ -13,15 +14,22 @@ export default function Debug({ route }) {
 
   React.useEffect(() => {
     if (
-      data &&
       data?.getLaunchConfigurations?.length &&
       !selectedConfig
     ) {
       setSelectedConfig(data.getLaunchConfigurations[0].name);
     }
   }, [data, selectedConfig]);
-  const [start, { loading: startLoading }] = useMutation(StartDebuggingDocument);
-  const [stop, { loading: stopLoading }] = useMutation(StopDebuggingDocument);
+  
+  const startError = useErrorAlert('Failed to start debugging');
+  const stopError = useErrorAlert('Failed to stop debugging');
+  
+  const [start, { loading: startLoading }] = useMutation(StartDebuggingDocument, {
+    onError: startError,
+  });
+  const [stop, { loading: stopLoading }] = useMutation(StopDebuggingDocument, {
+    onError: stopError,
+  });
 
   const { logs, appendLog, clearLogs, setActive, isActive } = useDebugStore();
 

--- a/apps/mobile/src/screens/Git.tsx
+++ b/apps/mobile/src/screens/Git.tsx
@@ -1,10 +1,76 @@
-import React, { useState } from 'react';
-import { View, Button, Text, SectionList, ActivityIndicator, StyleSheet, TouchableOpacity, Modal, TextInput } from 'react-native';
-import { useQuery, useMutation } from '@apollo/client';
+import React, { useState, useCallback } from 'react';
+import { View, Button, Text, SectionList, ActivityIndicator, StyleSheet, TouchableOpacity, Modal, TextInput, ScrollView } from 'react-native';
+import { useQuery, useMutation, useLazyQuery } from '@apollo/client';
+import { useErrorAlert } from '../hooks/useErrorAlert';
 import { GitStatusDocument, GitDiffDocument, GitStageDocument, GitUnstageDocument, CommitDocument, PushDocument } from 'shared/src/types';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
-export default function Git({ route }) {
+const ChangeItem = React.memo(function ChangeItem({ file, staged, onStage, onUnstage, onViewDiff, loading }: {
+  file: string;
+  staged: boolean;
+  onStage(): void;
+  onUnstage(): void;
+  onViewDiff(): void;
+  loading: boolean;
+}) {
+  return (
+    <TouchableOpacity style={styles.changeItem} onLongPress={onViewDiff}>
+      <Icon name="file-document-outline" size={20} color="#555" style={{ marginRight: 8 }} />
+      <Text style={[styles.path, { marginRight: 8 }]} numberOfLines={1} ellipsizeMode="middle">
+        {file}
+      </Text>
+      <Button
+        title={staged ? 'Unstage' : 'Stage'}
+        onPress={staged ? onUnstage : onStage}
+        disabled={loading}
+      />
+    </TouchableOpacity>
+  );
+});
+
+function DiffModal({ visible, diff, onClose }: { visible: boolean; diff: string; onClose(): void }) {
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={{ flex: 1, padding: 16 }}>
+        <ScrollView style={{ flex: 1 }}>
+          <Text style={{ fontFamily: 'monospace' }}>{diff}</Text>
+        </ScrollView>
+        <Button title="Close" onPress={onClose} />
+      </View>
+    </Modal>
+  );
+}
+
+function CommitModal({ visible, message, onMessage, onCommit, onCancel, loading }: {
+  visible: boolean;
+  message: string;
+  onMessage(text: string): void;
+  onCommit(): void;
+  onCancel(): void;
+  loading: boolean;
+}) {
+  return (
+    <Modal visible={visible} transparent>
+      <View style={styles.modalContainer}>
+        <View style={styles.modalView}>
+          <TextInput
+            placeholder="Commit message"
+            onChangeText={onMessage}
+            value={message}
+            multiline
+            style={styles.commitInput}
+          />
+          <View style={{ marginBottom: 8 }}>
+            <Button title="Commit" onPress={onCommit} disabled={loading} />
+          </View>
+          <Button title="Cancel" onPress={onCancel} color="gray" />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+export default function Git({ route }: any) {
   const { workspaceUri } = route.params;
   const { data, loading, refetch } = useQuery(GitStatusDocument, { variables: { workspaceUri }, fetchPolicy: 'cache-and-network' });
 
@@ -13,70 +79,89 @@ export default function Git({ route }) {
   const [diff, setDiff] = useState('');
   const [isDiffModalVisible, setDiffModalVisible] = useState(false);
 
-  const [stage, { loading: stageLoading }] = useMutation(GitStageDocument, { onCompleted: () => refetch() });
-  const [unstage, { loading: unstageLoading }] = useMutation(GitUnstageDocument, { onCompleted: () => refetch() });
-  const [commit, { loading: cLoading }] = useMutation(CommitDocument, { 
-    onCompleted: () => { 
-      setCommitModalVisible(false); 
-      setCommitMessage(''); 
-      refetch();
-    } 
+  const stageError = useErrorAlert('Failed to stage file');
+  const unstageError = useErrorAlert('Failed to unstage file');
+  const commitError = useErrorAlert('Commit failed');
+  const pushError = useErrorAlert('Push failed');
+  const diffError = useErrorAlert('Failed to load diff');
+
+  const [stage, { loading: stageLoading }] = useMutation(GitStageDocument, {
+    onCompleted: () => refetch(),
+    onError: stageError,
   });
-  const [push, { loading: pLoading }] = useMutation(PushDocument);
-  const [getDiff] = useLazyQuery(GitDiffDocument);
-
-  const handleViewDiff = async (file: string) => {
+  const [unstage, { loading: unstageLoading }] = useMutation(GitUnstageDocument, {
+    onCompleted: () => refetch(),
+    onError: unstageError,
+  });
+  const [commit, { loading: cLoading }] = useMutation(CommitDocument, {
+    onCompleted: () => {
+      setCommitModalVisible(false);
+      setCommitMessage('');
+      refetch();
+    },
+    onError: commitError,
+  });
+  const [push, { loading: pLoading }] = useMutation(PushDocument, {
+    onError: pushError,
+  });
+  const [getDiff] = useLazyQuery(GitDiffDocument, {
+    onError: diffError,
+  });
+  const handleViewDiff = useCallback(async (file: string) => {
     const res = await getDiff({ variables: { workspaceUri, file } });
-    setDiff(res.data?.gitDiff ?? 'Could not load diff.');
+    if (res.data?.gitDiff) {
+      setDiff(res.data.gitDiff);
+    } else {
+      setDiff('Could not load diff.');
+    }
     setDiffModalVisible(true);
-  };
+  }, [getDiff, workspaceUri]);
 
-  const renderChange = ({ item, section }) => {
-    const isStaged = section.title === 'Staged';
+  const handleStage = useCallback((file: string) => {
+    stage({ variables: { workspaceUri, file } });
+  }, [stage, workspaceUri]);
+
+  const handleUnstage = useCallback((file: string) => {
+    unstage({ variables: { workspaceUri, file } });
+  }, [unstage, workspaceUri]);
+
+  const renderChange = useCallback(({ item }: { item: string }) => {
+    const isStaged = data?.gitStatus.staged.includes(item);
     return (
-      <TouchableOpacity style={styles.changeItem} onLongPress={() => handleViewDiff(item)}>
-        <Icon name="file-document-outline" size={20} color="#555" />
-        <Text
-          style={styles.path}
-          numberOfLines={1}
-          ellipsizeMode="middle"
-        >
-          {item}
-        </Text>
-        <Button
-          title={isStaged ? 'Unstage' : 'Stage'}
-          onPress={() => isStaged ? unstage({ variables: { workspaceUri, file: item } }) : stage({ variables: { workspaceUri, file: item } }) }
-          disabled={stageLoading || unstageLoading}
-        />
-      </TouchableOpacity>
+      <ChangeItem
+        file={item}
+        staged={isStaged ?? false}
+        onStage={() => handleStage(item)}
+        onUnstage={() => handleUnstage(item)}
+        onViewDiff={() => handleViewDiff(item)}
+        loading={stageLoading || unstageLoading}
+      />
     );
-  };
+  }, [data, handleStage, handleUnstage, handleViewDiff, stageLoading, unstageLoading]);
 
   if (loading && !data) return <ActivityIndicator style={styles.center} size="large" />;
 
   const sections = [
     { title: 'Staged', data: data?.gitStatus.staged ?? [] },
-    { title: 'Unstaged', data: data?.gitStatus.unstaged ?? [] }
+    { title: 'Unstaged', data: data?.gitStatus.unstaged ?? [] },
   ];
 
   return (
     <View style={styles.container}>
-      <Modal visible={isDiffModalVisible} animationType="slide">
-        <View style={{ flex: 1, padding: 16 }}>
-          <Text style={{ fontFamily: 'monospace' }}>{diff}</Text>
-          <Button title="Close" onPress={() => setDiffModalVisible(false)} />
-        </View>
-      </Modal>
+      <DiffModal
+        visible={isDiffModalVisible}
+        diff={diff}
+        onClose={() => setDiffModalVisible(false)}
+      />
 
-      <Modal visible={isCommitModalVisible} transparent>
-        <View style={styles.modalContainer}>
-          <View style={styles.modalView}>
-            <TextInput placeholder="Commit message" onChangeText={setCommitMessage} multiline style={styles.commitInput} />
-            <Button title="Commit" onPress={() => commit({ variables: { workspaceUri, message: commitMessage } })} disabled={cLoading} />
-            <Button title="Cancel" onPress={() => setCommitModalVisible(false)} color="gray" />
-          </View>
-        </View>
-      </Modal>
+      <CommitModal
+        visible={isCommitModalVisible}
+        message={commitMessage}
+        onMessage={setCommitMessage}
+        onCommit={() => commit({ variables: { workspaceUri, message: commitMessage } })}
+        onCancel={() => setCommitModalVisible(false)}
+        loading={cLoading}
+      />
 
       <View style={styles.header}>
         <Text>Branch: {data?.gitStatus.branch}</Text>
@@ -86,23 +171,27 @@ export default function Git({ route }) {
         sections={sections}
         renderItem={renderChange}
         renderSectionHeader={({ section }) => <Text style={styles.sectionHeader}>{section.title} ({section.data.length})</Text>}
-        keyExtractor={(item, index) => item + index}
+        keyExtractor={(item) => item}
         onRefresh={refetch}
         refreshing={loading}
       />
-      <Button title="Commit Staged" onPress={() => setCommitModalVisible(true)} disabled={!data?.gitStatus.staged.length} />
+      <Button
+        title="Commit Staged"
+        onPress={() => setCommitModalVisible(true)}
+        disabled={!(data?.gitStatus.staged ?? []).length}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16, gap: 8 },
+  container: { flex: 1, padding: 16 },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
   sectionHeader: { fontWeight: 'bold', marginTop: 8 },
-  changeItem: { flexDirection: 'row', alignItems: 'center', paddingVertical: 4, gap: 8 },
+  changeItem: { flexDirection: 'row', alignItems: 'center', paddingVertical: 4, marginBottom: 8 },
   path: { flex: 1, fontFamily: 'monospace' },
   modalContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' },
-  modalView: { backgroundColor: 'white', padding: 16, width: '80%', gap: 8, borderRadius: 4 },
+  modalView: { backgroundColor: 'white', padding: 16, width: '80%', borderRadius: 4 },
   commitInput: { borderWidth: 1, borderColor: '#ccc', marginBottom: 8, padding: 8, minHeight: 60 },
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 });

--- a/packages/react-native-monaco-editor/src/index.tsx
+++ b/packages/react-native-monaco-editor/src/index.tsx
@@ -1,38 +1,40 @@
-import React, { forwardRef, useImperativeHandle, useRef, useMemo, useEffect } from 'react';
+import React, { useEffect, useRef, forwardRef, useImperativeHandle, memo, useMemo } from 'react';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
 import * as Y from 'yjs';
 import { editorHtml } from './editor-html';
+import type { CursorPosition } from './types';
 
 export interface MonacoEditorRef {
   revealLineInCenter: (lineNumber: number, scroll?: number) => void;
   getEditor: () => unknown;
 }
 
-export interface CursorPosition {
-  lineNumber: number;
-  column: number;
-}
-
-export interface MonacoEditorProps {
+interface Props {
   doc: Y.Text;
   language?: string;
   onContentChange?: (content: string) => void;
-  onCursorChange?: (position: CursorPosition) => void;
+  onCursorChange?: (pos: CursorPosition) => void;
   remoteCursors?: { position: CursorPosition; color: string; name: string }[];
   style?: object;
   onLoad?: () => void;
 }
 
-const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
-  ({ doc, language = 'plaintext', onContentChange, onCursorChange, remoteCursors, style, onLoad }, ref) => {
+const MonacoEditorInner = (
+  { doc, language = 'plaintext', onContentChange, onCursorChange, remoteCursors, style, onLoad }: Props,
+  ref: React.Ref<MonacoEditorRef>
+) => {
     const webviewRef = useRef<WebView>(null);
     const editorRef = useRef<unknown>(null);
+    
+    const initialText = useMemo(() => {
+        // Use JSON.stringify to robustly escape characters for JS context
+        return JSON.stringify(doc.toString()).slice(1, -1);
+    }, [doc]);
 
-    const initialText = useMemo(() => doc.toString().replace(/`/g, '\\`'), [doc]);
     const htmlContent = useMemo(() => editorHtml(initialText, language), [initialText, language]);
 
     useImperativeHandle(ref, () => ({
-      revealLineInCenter: (lineNumber, scroll = 1) => {
+      revealLineInCenter: (lineNumber: number, scroll = 1) => {
         const command = `editor.revealLineInCenter(${lineNumber}, ${scroll});`;
         webviewRef.current?.injectJavaScript(command);
       },
@@ -41,28 +43,27 @@ const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
 
     const handleMessage = (event: WebViewMessageEvent) => {
       try {
-        let message: { type: string; payload: unknown };
-        try {
-          message = JSON.parse(event.nativeEvent.data);
-        } catch (error) {
-          console.warn('Failed to parse WebView message:', error);
-          return;
-        }
-        switch (message.type) {
+        const { type, payload } = JSON.parse(event.nativeEvent.data);
+        
+        switch (type) {
           case 'editorDidMount':
-            editorRef.current = message.payload;
+            editorRef.current = payload;
             onLoad?.();
             break;
-          case 'contentDidChange':
-            onContentChange?.((message.payload as { value: string }).value);
+          case 'contentDidChange': {
+            if (
+              payload &&
+              typeof payload === 'object' &&
+              'value' in payload &&
+              typeof (payload as any).value === 'string'
+            ) {
+              onContentChange?.((payload as { value: string }).value);
+            }
             break;
+          }
           case 'cursorDidChange':
-            onCursorChange?.(
-              (message.payload as { position: CursorPosition }).position
-            );
+            onCursorChange?.((payload as { position: CursorPosition }).position);
             break;
-          default:
-            console.warn(`Unknown message type from WebView: ${message.type}`);
         }
       } catch (e) {
         console.error('Failed to parse message from WebView', e);
@@ -71,7 +72,18 @@ const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
 
     useEffect(() => {
       if (remoteCursors && remoteCursors.length > 0) {
-        const script = `\n                const decorations = ${JSON.stringify(remoteCursors)}.map(cursor => ({\n                    range: new monaco.Range(cursor.position.lineNumber, cursor.position.column, cursor.position.lineNumber, cursor.position.column),\n                    options: {\n                        className: 'remote-cursor',\n                        stickiness: 1,\n                        afterContentClassName: 'remote-cursor-label',\n                        after: { content: \`${cursor.name}\` }\n                    }\n                }));\n                editor.deltaDecorations([], decorations);\n            `;
+        const script = `
+                const decorations = ${JSON.stringify(remoteCursors)}.map(cursor => ({
+                    range: new monaco.Range(cursor.position.lineNumber, cursor.position.column, cursor.position.lineNumber, cursor.position.column),
+                    options: {
+                        className: 'remote-cursor',
+                        stickiness: 1,
+                        afterContentClassName: 'remote-cursor-label',
+                        after: { content: cursor.name }
+                    }
+                }));
+                editor.deltaDecorations([], decorations);
+            `;
         webviewRef.current?.injectJavaScript(script);
       }
     }, [remoteCursors]);
@@ -88,8 +100,8 @@ const MonacoEditor = forwardRef<MonacoEditorRef, MonacoEditorProps>(
         onShouldStartLoadWithRequest={event => event.url === 'about:blank'}
       />
     );
-  }
-);
+  };
+
+const MonacoEditor = memo(forwardRef<MonacoEditorRef, Props>(MonacoEditorInner));
 
 export default MonacoEditor;
-

--- a/packages/react-native-monaco-editor/src/types.ts
+++ b/packages/react-native-monaco-editor/src/types.ts
@@ -1,0 +1,4 @@
+export interface CursorPosition {
+  lineNumber: number;
+  column: number;
+}


### PR DESCRIPTION
## Summary
- update Jest config for VS Code mock
- add server logic cleanup and HTTPS upgrade fix
- refine CRDT persistence with unbind support
- include vscode mock for tests

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6876fa82a174833387970d9a23ef6cbb

## Summary by Sourcery

Fix server test setup, persistence, and client UI consistency across mobile, editor, and backend packages

New Features:
- Add ChangeItem, DiffModal, and CommitModal components to mobile Git screen
- Integrate useErrorAlert hook for client-side mutation error handling
- Introduce unbindState function to CRDT persistence module for explicit cleanup
- Provide a dedicated vscode mock file under backend/__mocks__ for Jest

Bug Fixes:
- Fix HTTP upgrade handler to log missing URL errors and destroy invalid sockets
- Resolve Jest mock issues by mapping vscode in jest.config.js and using inline mocks to avoid ts-jest circular dependency errors

Enhancements:
- Refactor mobile Git screen with useCallback, useLazyQuery, and component memoization
- Enhance react-native-monaco-editor with explicit typing, memoization, robust escaping, and message validation
- Streamline server startup with async/await, clean WebSocket upgrade logic, hardcode HTTPS protocol, and unify shutdown cleanup
- Standardize GraphQL resolvers by renaming path parameters, removing redundancy, and using FS_EVENT/DEBUG_EVENT constants
- Update gitProvider to derive staged and unstaged files from status flags
- Improve CRDT persistence with debug-level logging, temp file cleanup warnings, and error-handled saver refresh

Build:
- Adjust backend Jest configuration to map vscode imports to the mock implementation

Tests:
- Update backend server and watcher tests to use new mocks and event constants
- Refine resolver tests to mock workspace folder and path conversion appropriately