### PR TITLE
Fix P0 mobile bootstrap and connectivity

### DIFF
--- a/apps/backend/src/core/auth.test.ts
+++ b/apps/backend/src/core/auth.test.ts
@@ -1,0 +1,82 @@
+import type { NextFunction, Response } from 'express';
+import * as jwt from 'jsonwebtoken';
+import { PAIRING_OPERATION_NAME, pairingMiddleware } from './auth';
+import type { AuthContext, RequestWithUser } from './auth';
+
+jest.mock('../ui/uiState', () => ({ setServerUiState: jest.fn() }));
+jest.mock('../ui/logger', () => ({ logInfo: jest.fn(), logWarn: jest.fn() }));
+
+function createResponse() {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+
+  return {
+    response: { json, status } as unknown as Response,
+    json,
+    status,
+  };
+}
+
+describe('pairingMiddleware', () => {
+  const createContext = (): AuthContext => ({
+    jwtSecret: 'test-secret',
+    pairingToken: 'ABC123',
+    isPaired: false,
+  });
+
+  it('handles the generated PairWithServer operation and returns a signed token', () => {
+    const authContext = createContext();
+    const request = {
+      body: {
+        operationName: PAIRING_OPERATION_NAME,
+        variables: { pairingToken: authContext.pairingToken },
+      },
+    } as RequestWithUser;
+    const { response, json } = createResponse();
+    const next = jest.fn() as NextFunction;
+
+    pairingMiddleware(authContext)(request, response, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(authContext.isPaired).toBe(true);
+    expect(json).toHaveBeenCalledTimes(1);
+
+    const payload = json.mock.calls[0][0] as { data: { pairWithServer: string } };
+    expect(jwt.verify(payload.data.pairWithServer, authContext.jwtSecret)).toMatchObject({
+      paired: true,
+    });
+  });
+
+  it('passes non-pairing operations to JWT authentication', () => {
+    const authContext = createContext();
+    const request = {
+      body: { operationName: 'ListWorkspaces', variables: {} },
+    } as RequestWithUser;
+    const { response, json, status } = createResponse();
+    const next = jest.fn() as NextFunction;
+
+    pairingMiddleware(authContext)(request, response, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid pairing token', () => {
+    const authContext = createContext();
+    const request = {
+      body: {
+        operationName: PAIRING_OPERATION_NAME,
+        variables: { pairingToken: 'WRONG' },
+      },
+    } as RequestWithUser;
+    const { response, json, status } = createResponse();
+    const next = jest.fn() as NextFunction;
+
+    pairingMiddleware(authContext)(request, response, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: 'Invalid pairing token' });
+  });
+});

--- a/apps/backend/src/core/auth.ts
+++ b/apps/backend/src/core/auth.ts
@@ -48,6 +48,8 @@ export async function ensureAuthContext(): Promise<AuthContext | null> {
 
 export type RequestWithUser = Request & { user?: string | jwt.JwtPayload };
 
+export const PAIRING_OPERATION_NAME = 'PairWithServer';
+
 export function pairingMiddleware(authContext: AuthContext) {
   return (req: RequestWithUser, res: Response, next: NextFunction) => {
     if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
@@ -55,7 +57,7 @@ export function pairingMiddleware(authContext: AuthContext) {
     }
 
     const { operationName, variables } = req.body;
-    if (operationName !== 'pairWithServer') {
+    if (operationName !== PAIRING_OPERATION_NAME) {
       return next();
     }
 

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,9 +1,5 @@
-# Copy to .env for repository scripts.
-# Base URL of the VS Code extension server, without /graphql or /yjs.
+# Copy to apps/mobile/.env for local Expo development.
 # Physical devices: use the LAN address of the computer running VS Code.
 # iOS Simulator: http://127.0.0.1:4000
 # Android Emulator: http://10.0.2.2:4000
 EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL=http://YOUR_COMPUTER_IP_HERE:4000
-
-# Backward-compatible host-only fallback used when the full URL is unset.
-LOCAL_IP=YOUR_COMPUTER_IP_HERE

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,29 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
-function normalizeServerOrigin(rawValue) {
-  const value = rawValue.trim();
-
-  if (value.includes('YOUR_COMPUTER_IP_HERE')) {
-    throw new Error('Replace YOUR_COMPUTER_IP_HERE in EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL.');
-  }
-
-  const url = new URL(value);
-
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error('EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL must use http:// or https://.');
-  }
-
-  if (url.username || url.password || url.search || url.hash) {
-    throw new Error('EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL must be a plain origin.');
-  }
-
-  if (url.pathname !== '/' && url.pathname !== '') {
-    throw new Error('EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL must not include a path.');
-  }
-
-  return `${url.protocol}//${url.host}`;
-}
+const { normalizeServerOrigin } = require('./shared/normalizeServerOrigin');
 
 function pluginName(plugin) {
   return Array.isArray(plugin) ? plugin[0] : plugin;

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,36 +1,72 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
-module.exports = ({ config }) => {
-  const LOCAL_IP = process.env.LOCAL_IP || '127.0.0.1';
+function normalizeServerOrigin(rawValue) {
+  const value = rawValue.trim();
 
-  // IMPORTANT for CI:
-  // Non-interactive EAS builds require the EAS project to be configured.
-  // For dynamic config (app.config.js), EAS cannot always auto-write the projectId,
-  // so we inject it from env (GitHub Secret: EAS_PROJECT_ID).
-  const EAS_PROJECT_ID =
+  if (value.includes('YOUR_COMPUTER_IP_HERE')) {
+    throw new Error('Replace YOUR_COMPUTER_IP_HERE in EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL.');
+  }
+
+  const url = new URL(value);
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL must use http:// or https://.');
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL must be a plain origin.');
+  }
+
+  if (url.pathname !== '/' && url.pathname !== '') {
+    throw new Error('EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL must not include a path.');
+  }
+
+  return `${url.protocol}//${url.host}`;
+}
+
+function pluginName(plugin) {
+  return Array.isArray(plugin) ? plugin[0] : plugin;
+}
+
+module.exports = ({ config }) => {
+  const baseConfig = config || {};
+  const localIp = process.env.LOCAL_IP || '127.0.0.1';
+  const serverOrigin = normalizeServerOrigin(
+    process.env.EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL || `http://${localIp}:4000`
+  );
+  const allowCleartext = serverOrigin.startsWith('http://');
+
+  const easProjectId =
     process.env.EAS_PROJECT_ID ||
-    (config && config.extra && config.extra.eas && config.extra.eas.projectId) ||
+    (baseConfig.extra && baseConfig.extra.eas && baseConfig.extra.eas.projectId) ||
     undefined;
 
-  const existingExtra = (config && config.extra) || {};
-  const existingEas = (existingExtra && existingExtra.eas) || {};
+  const existingExtra = baseConfig.extra || {};
+  const existingEas = existingExtra.eas || {};
+  const existingIos = baseConfig.ios || {};
+  const existingAndroid = baseConfig.android || {};
+  const existingInfoPlist = existingIos.infoPlist || {};
+  const existingAts = existingInfoPlist.NSAppTransportSecurity || {};
+  const existingPlugins = Array.isArray(baseConfig.plugins) ? baseConfig.plugins : [];
+  const managedPluginNames = new Set([
+    './plugins/with-mobile-vscode-networking',
+  ]);
 
   const eas = {
     ...existingEas,
-    ...(EAS_PROJECT_ID ? { projectId: EAS_PROJECT_ID } : {}),
+    ...(easProjectId ? { projectId: easProjectId } : {}),
   };
 
   return {
-    ...config,
+    ...baseConfig,
     name: 'MobileVSCode',
     slug: 'mobile-vscode',
     scheme: 'mobilevscode',
     version: '0.1.0',
-    orientation: 'portrait',
+    orientation: baseConfig.orientation || 'default',
     platforms: ['ios', 'android'],
 
-    // Prefer root-level assets, but also duplicated in apps/mobile/assets
     icon: path.join(__dirname, '..', 'assets', 'icon.png'),
     splash: {
       image: path.join(__dirname, '..', 'assets', 'splash.png'),
@@ -41,12 +77,39 @@ module.exports = ({ config }) => {
     updates: { fallbackToCacheTimeout: 0 },
     assetBundlePatterns: ['**/*'],
 
-    ios: { bundleIdentifier: 'com.codex.mobilevscode', supportsTablet: true },
-    android: { package: 'com.codex.mobilevscode' },
+    ios: {
+      ...existingIos,
+      bundleIdentifier: existingIos.bundleIdentifier || 'com.codex.mobilevscode',
+      supportsTablet: true,
+      config: {
+        ...(existingIos.config || {}),
+        usesNonExemptEncryption: false,
+      },
+      infoPlist: {
+        ...existingInfoPlist,
+        NSLocalNetworkUsageDescription:
+          existingInfoPlist.NSLocalNetworkUsageDescription ||
+          'MobileVSCode connects to your VS Code server to browse, edit, and run workspace actions.',
+        NSAppTransportSecurity: {
+          ...existingAts,
+          NSAllowsLocalNetworking: true,
+        },
+      },
+    },
+    android: {
+      ...existingAndroid,
+      package: existingAndroid.package || 'com.codex.mobilevscode',
+    },
+
+    plugins: [
+      ...existingPlugins.filter(plugin => !managedPluginNames.has(pluginName(plugin))),
+      ['./plugins/with-mobile-vscode-networking', { allowCleartext }],
+    ],
 
     extra: {
       ...existingExtra,
-      LOCAL_IP,
+      LOCAL_IP: localIp,
+      MOBILE_VSCODE_SERVER_URL: serverOrigin,
       eas,
     },
   };

--- a/apps/mobile/modules/mobile-vscode-secure-store/android/build.gradle
+++ b/apps/mobile/modules/mobile-vscode-secure-store/android/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules.mobilevscodesecurestore'
+version = '0.1.0'
+
+android {
+  namespace 'expo.modules.mobilevscodesecurestore'
+
+  defaultConfig {
+    versionCode 1
+    versionName '0.1.0'
+  }
+
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/apps/mobile/modules/mobile-vscode-secure-store/android/src/main/AndroidManifest.xml
+++ b/apps/mobile/modules/mobile-vscode-secure-store/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/apps/mobile/modules/mobile-vscode-secure-store/android/src/main/java/expo/modules/mobilevscodesecurestore/MobileVSCodeSecureStoreModule.kt
+++ b/apps/mobile/modules/mobile-vscode-secure-store/android/src/main/java/expo/modules/mobilevscodesecurestore/MobileVSCodeSecureStoreModule.kt
@@ -5,6 +5,7 @@ import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.KeyProperties
 import android.util.Base64
+import android.util.Log
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
@@ -165,21 +166,27 @@ class MobileVSCodeSecureStoreModule : Module() {
       cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(tagLength, iv))
       return@synchronized String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8)
     } catch (error: KeyPermanentlyInvalidatedException) {
+      Log.w(TAG, "Secure storage key was permanently invalidated.", error)
       invalidateValue(persistedKey, alias)
       return@synchronized null
     } catch (error: AEADBadTagException) {
+      Log.w(TAG, "Secure storage authentication failed.", error)
       invalidateValue(persistedKey, alias)
       return@synchronized null
     } catch (error: BadPaddingException) {
+      Log.w(TAG, "Secure storage padding validation failed.", error)
       invalidateValue(persistedKey, alias)
       return@synchronized null
     } catch (error: UnrecoverableKeyException) {
+      Log.w(TAG, "Secure storage key could not be recovered.", error)
       invalidateValue(persistedKey, alias)
       return@synchronized null
     } catch (error: JSONException) {
+      Log.w(TAG, "Secure storage payload was invalid JSON.", error)
       preferences().edit().remove(persistedKey).commit()
       return@synchronized null
     } catch (error: IllegalArgumentException) {
+      Log.w(TAG, "Secure storage payload was malformed.", error)
       preferences().edit().remove(persistedKey).commit()
       return@synchronized null
     } catch (error: MobileVSCodeSecureStoreException) {
@@ -206,6 +213,7 @@ class MobileVSCodeSecureStoreModule : Module() {
   }
 
   companion object {
+    private const val TAG = "MVSC-SecureStore"
     private const val ANDROID_KEYSTORE = "AndroidKeyStore"
     private const val PREFERENCES_NAME = "MobileVSCodeSecureStore"
     private const val KEYSTORE_ALIAS_PREFIX = "mobile-vscode-secure-store"

--- a/apps/mobile/modules/mobile-vscode-secure-store/android/src/main/java/expo/modules/mobilevscodesecurestore/MobileVSCodeSecureStoreModule.kt
+++ b/apps/mobile/modules/mobile-vscode-secure-store/android/src/main/java/expo/modules/mobilevscodesecurestore/MobileVSCodeSecureStoreModule.kt
@@ -1,0 +1,224 @@
+package expo.modules.mobilevscodesecurestore
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.Serializable
+import java.nio.charset.StandardCharsets
+import java.security.GeneralSecurityException
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.UnrecoverableKeyException
+import javax.crypto.AEADBadTagException
+import javax.crypto.BadPaddingException
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+@OptimizedRecord
+internal class MobileVSCodeSecureStoreOptions(
+  @Field var keychainService: String = DEFAULT_KEYCHAIN_SERVICE
+) : Record, Serializable
+
+internal class MobileVSCodeSecureStoreException(message: String, cause: Throwable? = null) :
+  CodedException(message, cause)
+
+class MobileVSCodeSecureStoreModule : Module() {
+  private val cryptoLock = Any()
+
+  private val reactContext: Context
+    get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+
+  override fun definition() = ModuleDefinition {
+    Name("MobileVSCodeSecureStore")
+
+    AsyncFunction("getValueWithKeyAsync") { key: String, options: MobileVSCodeSecureStoreOptions ->
+      validate(key, options.keychainService)
+      getValue(key, options.keychainService)
+    }
+
+    AsyncFunction("setValueWithKeyAsync") { value: String, key: String, options: MobileVSCodeSecureStoreOptions ->
+      validate(key, options.keychainService)
+      setValue(key, value, options.keychainService)
+      true
+    }
+
+    AsyncFunction("deleteValueWithKeyAsync") { key: String, options: MobileVSCodeSecureStoreOptions ->
+      validate(key, options.keychainService)
+      deleteValue(key, options.keychainService)
+    }
+  }
+
+  private fun validate(key: String, service: String) {
+    if (key.isBlank()) {
+      throw MobileVSCodeSecureStoreException("Secure storage keys cannot be empty.")
+    }
+    if (service.isBlank()) {
+      throw MobileVSCodeSecureStoreException("The secure storage keychain service cannot be empty.")
+    }
+  }
+
+  private fun preferences() = reactContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+  private fun storageKey(key: String, service: String): String {
+    val bytes = MessageDigest.getInstance("SHA-256")
+      .digest("$service\u0000$key".toByteArray(StandardCharsets.UTF_8))
+    return Base64.encodeToString(bytes, Base64.NO_WRAP or Base64.NO_PADDING or Base64.URL_SAFE)
+  }
+
+  private fun keyStoreAlias(service: String) = "$KEYSTORE_ALIAS_PREFIX:$service"
+
+  private fun loadKeyStore(): KeyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply {
+    load(null)
+  }
+
+  private fun getOrCreateSecretKey(alias: String): SecretKey {
+    val keyStore = loadKeyStore()
+    (keyStore.getKey(alias, null) as? SecretKey)?.let { return it }
+
+    val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+    val keySpec = KeyGenParameterSpec.Builder(
+      alias,
+      KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+    )
+      .setKeySize(AES_KEY_SIZE_BITS)
+      .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+      .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+      .setRandomizedEncryptionRequired(true)
+      .setUserAuthenticationRequired(false)
+      .build()
+
+    keyGenerator.init(keySpec)
+    return keyGenerator.generateKey()
+  }
+
+  private fun existingSecretKey(alias: String): SecretKey? {
+    val keyStore = loadKeyStore()
+    if (!keyStore.containsAlias(alias)) return null
+    return keyStore.getKey(alias, null) as? SecretKey
+  }
+
+  private fun setValue(key: String, value: String, service: String) = synchronized(cryptoLock) {
+    val alias = keyStoreAlias(service)
+    try {
+      val cipher = Cipher.getInstance(AES_CIPHER)
+      cipher.init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey(alias))
+      val ciphertext = cipher.doFinal(value.toByteArray(StandardCharsets.UTF_8))
+      val encoded = JSONObject()
+        .put(VERSION_PROPERTY, CURRENT_VERSION)
+        .put(CIPHERTEXT_PROPERTY, Base64.encodeToString(ciphertext, Base64.NO_WRAP))
+        .put(IV_PROPERTY, Base64.encodeToString(cipher.iv, Base64.NO_WRAP))
+        .put(TAG_LENGTH_PROPERTY, GCM_TAG_LENGTH_BITS)
+        .toString()
+
+      val committed = preferences().edit().putString(storageKey(key, service), encoded).commit()
+      if (!committed) {
+        throw MobileVSCodeSecureStoreException("Secure storage could not persist key '$key'.")
+      }
+    } catch (error: MobileVSCodeSecureStoreException) {
+      throw error
+    } catch (error: GeneralSecurityException) {
+      throw MobileVSCodeSecureStoreException("Secure storage encryption failed for key '$key'.", error)
+    } catch (error: JSONException) {
+      throw MobileVSCodeSecureStoreException("Secure storage could not encode key '$key'.", error)
+    }
+  }
+
+  private fun getValue(key: String, service: String): String? = synchronized(cryptoLock) {
+    val persistedKey = storageKey(key, service)
+    val encoded = preferences().getString(persistedKey, null) ?: return@synchronized null
+    val alias = keyStoreAlias(service)
+
+    try {
+      val secretKey = existingSecretKey(alias)
+      if (secretKey == null) {
+        preferences().edit().remove(persistedKey).commit()
+        return@synchronized null
+      }
+
+      val item = JSONObject(encoded)
+      if (item.optInt(VERSION_PROPERTY, -1) != CURRENT_VERSION) {
+        preferences().edit().remove(persistedKey).commit()
+        return@synchronized null
+      }
+
+      val tagLength = item.getInt(TAG_LENGTH_PROPERTY)
+      if (tagLength < MIN_GCM_TAG_LENGTH_BITS) {
+        throw MobileVSCodeSecureStoreException("Secure storage authentication tag is too short.")
+      }
+
+      val ciphertext = Base64.decode(item.getString(CIPHERTEXT_PROPERTY), Base64.DEFAULT)
+      val iv = Base64.decode(item.getString(IV_PROPERTY), Base64.DEFAULT)
+      val cipher = Cipher.getInstance(AES_CIPHER)
+      cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(tagLength, iv))
+      return@synchronized String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8)
+    } catch (error: KeyPermanentlyInvalidatedException) {
+      invalidateValue(persistedKey, alias)
+      return@synchronized null
+    } catch (error: AEADBadTagException) {
+      invalidateValue(persistedKey, alias)
+      return@synchronized null
+    } catch (error: BadPaddingException) {
+      invalidateValue(persistedKey, alias)
+      return@synchronized null
+    } catch (error: UnrecoverableKeyException) {
+      invalidateValue(persistedKey, alias)
+      return@synchronized null
+    } catch (error: JSONException) {
+      preferences().edit().remove(persistedKey).commit()
+      return@synchronized null
+    } catch (error: IllegalArgumentException) {
+      preferences().edit().remove(persistedKey).commit()
+      return@synchronized null
+    } catch (error: MobileVSCodeSecureStoreException) {
+      throw error
+    } catch (error: GeneralSecurityException) {
+      throw MobileVSCodeSecureStoreException("Secure storage decryption failed for key '$key'.", error)
+    }
+  }
+
+  private fun invalidateValue(persistedKey: String, alias: String) {
+    preferences().edit().remove(persistedKey).commit()
+    try {
+      loadKeyStore().deleteEntry(alias)
+    } catch (_: GeneralSecurityException) {
+      // The stored value is already unusable; re-pairing will create a fresh key.
+    }
+  }
+
+  private fun deleteValue(key: String, service: String) {
+    val removed = preferences().edit().remove(storageKey(key, service)).commit()
+    if (!removed) {
+      throw MobileVSCodeSecureStoreException("Secure storage could not delete key '$key'.")
+    }
+  }
+
+  companion object {
+    private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    private const val PREFERENCES_NAME = "MobileVSCodeSecureStore"
+    private const val KEYSTORE_ALIAS_PREFIX = "mobile-vscode-secure-store"
+    private const val AES_CIPHER = "AES/GCM/NoPadding"
+    private const val AES_KEY_SIZE_BITS = 256
+    private const val GCM_TAG_LENGTH_BITS = 128
+    private const val MIN_GCM_TAG_LENGTH_BITS = 96
+    private const val CURRENT_VERSION = 1
+    private const val VERSION_PROPERTY = "v"
+    private const val CIPHERTEXT_PROPERTY = "ct"
+    private const val IV_PROPERTY = "iv"
+    private const val TAG_LENGTH_PROPERTY = "tlen"
+  }
+}
+
+private const val DEFAULT_KEYCHAIN_SERVICE = "mobile-vscode.session"

--- a/apps/mobile/modules/mobile-vscode-secure-store/expo-module.config.json
+++ b/apps/mobile/modules/mobile-vscode-secure-store/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["android", "apple"],
+  "apple": {
+    "modules": ["MobileVSCodeSecureStoreModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.mobilevscodesecurestore.MobileVSCodeSecureStoreModule"]
+  }
+}

--- a/apps/mobile/modules/mobile-vscode-secure-store/index.ts
+++ b/apps/mobile/modules/mobile-vscode-secure-store/index.ts
@@ -1,0 +1,66 @@
+import { requireOptionalNativeModule } from 'expo';
+
+type NativeSecureStore = {
+  getValueWithKeyAsync: (key: string, options: SecureStoreOptions) => Promise<string | null>;
+  setValueWithKeyAsync: (value: string, key: string, options: SecureStoreOptions) => Promise<boolean>;
+  deleteValueWithKeyAsync: (key: string, options: SecureStoreOptions) => Promise<void>;
+};
+
+type SecureStoreOptions = {
+  keychainService: string;
+};
+
+const KEY_PATTERN = /^[\w.-]+$/;
+const OPTIONS: SecureStoreOptions = {
+  keychainService: 'mobile-vscode.session',
+};
+
+const nativeStore = requireOptionalNativeModule<NativeSecureStore>('MobileVSCodeSecureStore');
+let didWarnAboutUnavailableStore = false;
+
+function validateKey(key: string): void {
+  if (!KEY_PATTERN.test(key)) {
+    throw new Error(
+      'Invalid secure-storage key. Keys must contain only alphanumeric characters, ".", "-", and "_".'
+    );
+  }
+}
+
+function warnIfUnavailable(): void {
+  if (didWarnAboutUnavailableStore) return;
+  didWarnAboutUnavailableStore = true;
+  console.warn(
+    'MobileVSCode secure session persistence is unavailable in this client. ' +
+      'The current session will work, but the device must pair again after the app restarts. ' +
+      'Use an iOS or Android development build for Keychain/Keystore persistence.'
+  );
+}
+
+export async function getItemAsync(key: string): Promise<string | null> {
+  validateKey(key);
+  if (!nativeStore) {
+    warnIfUnavailable();
+    return null;
+  }
+  return nativeStore.getValueWithKeyAsync(key, OPTIONS);
+}
+
+export async function setItemAsync(key: string, value: string): Promise<void> {
+  validateKey(key);
+  if (typeof value !== 'string') {
+    throw new Error('Secure-storage values must be strings.');
+  }
+
+  if (!nativeStore) {
+    warnIfUnavailable();
+    return;
+  }
+
+  await nativeStore.setValueWithKeyAsync(value, key, OPTIONS);
+}
+
+export async function deleteItemAsync(key: string): Promise<void> {
+  validateKey(key);
+  if (!nativeStore) return;
+  await nativeStore.deleteValueWithKeyAsync(key, OPTIONS);
+}

--- a/apps/mobile/modules/mobile-vscode-secure-store/index.web.ts
+++ b/apps/mobile/modules/mobile-vscode-secure-store/index.web.ts
@@ -1,12 +1,20 @@
 const UNSUPPORTED_MESSAGE =
-  'MobileVSCode secure session storage is unavailable on web. Use an iOS or Android development build.';
+  'MobileVSCode secure session storage is unavailable on web. The current session will not persist after the app restarts.';
+
+let didWarnAboutUnsupportedStorage = false;
+
+function warnIfUnsupported(): void {
+  if (didWarnAboutUnsupportedStorage) return;
+  didWarnAboutUnsupportedStorage = true;
+  console.warn(UNSUPPORTED_MESSAGE);
+}
 
 export async function getItemAsync(_key: string): Promise<string | null> {
   return null;
 }
 
 export async function setItemAsync(_key: string, _value: string): Promise<void> {
-  throw new Error(UNSUPPORTED_MESSAGE);
+  warnIfUnsupported();
 }
 
 export async function deleteItemAsync(_key: string): Promise<void> {

--- a/apps/mobile/modules/mobile-vscode-secure-store/index.web.ts
+++ b/apps/mobile/modules/mobile-vscode-secure-store/index.web.ts
@@ -1,0 +1,14 @@
+const UNSUPPORTED_MESSAGE =
+  'MobileVSCode secure session storage is unavailable on web. Use an iOS or Android development build.';
+
+export async function getItemAsync(_key: string): Promise<string | null> {
+  return null;
+}
+
+export async function setItemAsync(_key: string, _value: string): Promise<void> {
+  throw new Error(UNSUPPORTED_MESSAGE);
+}
+
+export async function deleteItemAsync(_key: string): Promise<void> {
+  // Nothing is persisted on web.
+}

--- a/apps/mobile/modules/mobile-vscode-secure-store/ios/MobileVSCodeSecureStore.podspec
+++ b/apps/mobile/modules/mobile-vscode-secure-store/ios/MobileVSCodeSecureStore.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name             = 'MobileVSCodeSecureStore'
+  s.version          = '0.1.0'
+  s.summary          = 'Device-bound session storage for MobileVSCode.'
+  s.description      = 'Stores the MobileVSCode session token in iOS Keychain.'
+  s.author           = 'MobileVSCode contributors'
+  s.homepage         = 'https://github.com/ales27pm/mobile-vscode-project'
+  s.platform         = :ios, '15.1'
+  s.swift_version    = '5.9'
+  s.source           = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+  s.frameworks = 'Security'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES'
+  }
+
+  s.source_files = '**/*.{h,m,mm,swift,hpp,cpp}'
+end

--- a/apps/mobile/modules/mobile-vscode-secure-store/ios/MobileVSCodeSecureStoreModule.swift
+++ b/apps/mobile/modules/mobile-vscode-secure-store/ios/MobileVSCodeSecureStoreModule.swift
@@ -1,0 +1,127 @@
+import ExpoModulesCore
+import Security
+
+internal struct MobileVSCodeSecureStoreOptions: Record {
+  @Field
+  var keychainService: String = "mobile-vscode.session"
+}
+
+public final class MobileVSCodeSecureStoreModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("MobileVSCodeSecureStore")
+
+    AsyncFunction("getValueWithKeyAsync") { (key: String, options: MobileVSCodeSecureStoreOptions) -> String? in
+      try validate(key: key, service: options.keychainService)
+      return try getValue(for: key, service: options.keychainService)
+    }
+
+    AsyncFunction("setValueWithKeyAsync") { (value: String, key: String, options: MobileVSCodeSecureStoreOptions) -> Bool in
+      try validate(key: key, service: options.keychainService)
+      try setValue(value, for: key, service: options.keychainService)
+      return true
+    }
+
+    AsyncFunction("deleteValueWithKeyAsync") { (key: String, options: MobileVSCodeSecureStoreOptions) in
+      try validate(key: key, service: options.keychainService)
+      try deleteValue(for: key, service: options.keychainService)
+    }
+  }
+
+  private func validate(key: String, service: String) throws {
+    guard !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw secureStoreError(operation: "validate", status: errSecParam, detail: "The key cannot be empty.")
+    }
+
+    guard !service.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw secureStoreError(operation: "validate", status: errSecParam, detail: "The keychain service cannot be empty.")
+    }
+  }
+
+  private func baseQuery(for key: String, service: String) -> [String: Any] {
+    return [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: key
+    ]
+  }
+
+  private func getValue(for key: String, service: String) throws -> String? {
+    var query = baseQuery(for: key, service: service)
+    query[kSecMatchLimit as String] = kSecMatchLimitOne
+    query[kSecReturnData as String] = kCFBooleanTrue
+
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+    switch status {
+    case errSecSuccess:
+      guard let data = result as? Data, let value = String(data: data, encoding: .utf8) else {
+        throw secureStoreError(operation: "read", status: errSecDecode, detail: "The stored value is not valid UTF-8.")
+      }
+      return value
+    case errSecItemNotFound:
+      return nil
+    default:
+      throw secureStoreError(operation: "read", status: status)
+    }
+  }
+
+  private func setValue(_ value: String, for key: String, service: String) throws {
+    let valueData = Data(value.utf8)
+    let query = baseQuery(for: key, service: service)
+    let updateAttributes: [String: Any] = [
+      kSecValueData as String: valueData,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ]
+
+    let updateStatus = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
+
+    switch updateStatus {
+    case errSecSuccess:
+      return
+    case errSecItemNotFound:
+      var addQuery = query
+      updateAttributes.forEach { addQuery[$0.key] = $0.value }
+      let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+
+      if addStatus == errSecSuccess {
+        return
+      }
+
+      if addStatus == errSecDuplicateItem {
+        let retryStatus = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
+        guard retryStatus == errSecSuccess else {
+          throw secureStoreError(operation: "update", status: retryStatus)
+        }
+        return
+      }
+
+      throw secureStoreError(operation: "write", status: addStatus)
+    default:
+      throw secureStoreError(operation: "update", status: updateStatus)
+    }
+  }
+
+  private func deleteValue(for key: String, service: String) throws {
+    let status = SecItemDelete(baseQuery(for: key, service: service) as CFDictionary)
+
+    if status != errSecSuccess && status != errSecItemNotFound {
+      throw secureStoreError(operation: "delete", status: status)
+    }
+  }
+
+  private func secureStoreError(
+    operation: String,
+    status: OSStatus,
+    detail: String? = nil
+  ) -> NSError {
+    let systemMessage = SecCopyErrorMessageString(status, nil) as String? ?? "Unknown Keychain error"
+    let message = detail ?? systemMessage
+
+    return NSError(
+      domain: "MobileVSCodeSecureStore",
+      code: Int(status),
+      userInfo: [NSLocalizedDescriptionKey: "Secure storage \(operation) failed: \(message)"]
+    )
+  }
+}

--- a/apps/mobile/modules/mobile-vscode-secure-store/ios/MobileVSCodeSecureStoreModule.swift
+++ b/apps/mobile/modules/mobile-vscode-secure-store/ios/MobileVSCodeSecureStoreModule.swift
@@ -69,36 +69,25 @@ public final class MobileVSCodeSecureStoreModule: Module {
   private func setValue(_ value: String, for key: String, service: String) throws {
     let valueData = Data(value.utf8)
     let query = baseQuery(for: key, service: service)
-    let updateAttributes: [String: Any] = [
-      kSecValueData as String: valueData,
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-    ]
+    var addQuery = query
+    addQuery[kSecValueData as String] = valueData
+    addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
 
-    let updateStatus = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
+    let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
 
-    switch updateStatus {
+    switch addStatus {
     case errSecSuccess:
       return
-    case errSecItemNotFound:
-      var addQuery = query
-      updateAttributes.forEach { addQuery[$0.key] = $0.value }
-      let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-
-      if addStatus == errSecSuccess {
-        return
+    case errSecDuplicateItem:
+      // Match Keychain's supported update path: keep the item's immutable
+      // accessibility metadata and replace only its secret value.
+      let updateAttributes = [kSecValueData as String: valueData]
+      let updateStatus = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
+      guard updateStatus == errSecSuccess else {
+        throw secureStoreError(operation: "update", status: updateStatus)
       }
-
-      if addStatus == errSecDuplicateItem {
-        let retryStatus = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
-        guard retryStatus == errSecSuccess else {
-          throw secureStoreError(operation: "update", status: retryStatus)
-        }
-        return
-      }
-
-      throw secureStoreError(operation: "write", status: addStatus)
     default:
-      throw secureStoreError(operation: "update", status: updateStatus)
+      throw secureStoreError(operation: "write", status: addStatus)
     }
   }
 

--- a/apps/mobile/plugins/with-mobile-vscode-networking.js
+++ b/apps/mobile/plugins/with-mobile-vscode-networking.js
@@ -1,0 +1,18 @@
+const { withAndroidManifest } = require('expo/config-plugins');
+
+module.exports = function withMobileVscodeNetworking(config, options = {}) {
+  const allowCleartext = options.allowCleartext === true;
+
+  return withAndroidManifest(config, androidConfig => {
+    const application = androidConfig.modResults.manifest.application?.[0];
+
+    if (!application) {
+      throw new Error('AndroidManifest.xml is missing its main application element.');
+    }
+
+    application.$ = application.$ || {};
+    application.$['android:usesCleartextTraffic'] = allowCleartext ? 'true' : 'false';
+
+    return androidConfig;
+  });
+};

--- a/apps/mobile/shared/normalizeServerOrigin.d.ts
+++ b/apps/mobile/shared/normalizeServerOrigin.d.ts
@@ -1,0 +1,1 @@
+export function normalizeServerOrigin(rawValue: string): string;

--- a/apps/mobile/shared/normalizeServerOrigin.js
+++ b/apps/mobile/shared/normalizeServerOrigin.js
@@ -1,0 +1,43 @@
+const INVALID_URL_MESSAGE =
+  'MobileVSCode server URL must include an http:// or https:// scheme.';
+
+function normalizeServerOrigin(rawValue) {
+  if (typeof rawValue !== 'string') {
+    throw new Error(INVALID_URL_MESSAGE);
+  }
+
+  const value = rawValue.trim();
+
+  if (value.includes('YOUR_COMPUTER_IP_HERE')) {
+    throw new Error('Replace YOUR_COMPUTER_IP_HERE in the MobileVSCode server URL.');
+  }
+
+  if (!/^[a-z][a-z\d+.-]*:\/\//i.test(value)) {
+    throw new Error(INVALID_URL_MESSAGE);
+  }
+
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(INVALID_URL_MESSAGE);
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('MobileVSCode server URL must use http:// or https://.');
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(
+      'MobileVSCode server URL must be a plain origin without credentials, query, or fragment.'
+    );
+  }
+
+  if (url.pathname !== '/' && url.pathname !== '') {
+    throw new Error('MobileVSCode server URL must not include /graphql, /yjs, or another path.');
+  }
+
+  return `${url.protocol}//${url.host}`;
+}
+
+module.exports = { normalizeServerOrigin };

--- a/apps/mobile/src/config.ts
+++ b/apps/mobile/src/config.ts
@@ -1,13 +1,57 @@
 import Constants from 'expo-constants';
 
-const LOCAL_IP = Constants.expoConfig?.extra?.LOCAL_IP || 'localhost';
+type MobileVscodeExtra = {
+  MOBILE_VSCODE_SERVER_URL?: unknown;
+  LOCAL_IP?: unknown;
+};
 
-if (LOCAL_IP === 'YOUR_COMPUTER_IP_HERE') {
-  console.warn("Please update the LOCAL_IP in your .env file. It is still set to the placeholder value.");
+function normalizeServerOrigin(rawValue: string): string {
+  const value = rawValue.trim();
+
+  if (value.includes('YOUR_COMPUTER_IP_HERE')) {
+    throw new Error('Replace YOUR_COMPUTER_IP_HERE in the MobileVSCode server URL.');
+  }
+
+  const url = new URL(value);
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('MobileVSCode server URL must use http:// or https://.');
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('MobileVSCode server URL must be a plain origin without credentials, query, or fragment.');
+  }
+
+  if (url.pathname !== '/' && url.pathname !== '') {
+    throw new Error('MobileVSCode server URL must not include /graphql, /yjs, or another path.');
+  }
+
+  return `${url.protocol}//${url.host}`;
 }
 
-const PORT = 4000;
+const extra = (Constants.expoConfig?.extra ?? {}) as MobileVscodeExtra;
+const configuredUrl =
+  process.env.EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL ??
+  (typeof extra.MOBILE_VSCODE_SERVER_URL === 'string'
+    ? extra.MOBILE_VSCODE_SERVER_URL
+    : undefined);
+const legacyHost =
+  typeof extra.LOCAL_IP === 'string' && extra.LOCAL_IP.trim()
+    ? extra.LOCAL_IP.trim()
+    : '127.0.0.1';
 
-export const GRAPHQL_URL = `https://${LOCAL_IP}:${PORT}/graphql`;
-export const WS_URL = `wss://${LOCAL_IP}:${PORT}/graphql`;
-export const YJS_URL = `wss://${LOCAL_IP}:${PORT}/yjs`;
+export const SERVER_ORIGIN = normalizeServerOrigin(
+  configuredUrl ?? `http://${legacyHost}:4000`
+);
+
+if (/^http:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(?::|$)/.test(SERVER_ORIGIN)) {
+  console.warn(
+    'MobileVSCode is configured for a loopback address. Set EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL to the VS Code host address before using a physical device.'
+  );
+}
+
+const websocketOrigin = SERVER_ORIGIN.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:');
+
+export const GRAPHQL_URL = `${SERVER_ORIGIN}/graphql`;
+export const WS_URL = `${websocketOrigin}/graphql`;
+export const YJS_URL = `${websocketOrigin}/yjs`;

--- a/apps/mobile/src/config.ts
+++ b/apps/mobile/src/config.ts
@@ -1,33 +1,10 @@
 import Constants from 'expo-constants';
+import { normalizeServerOrigin } from '../shared/normalizeServerOrigin';
 
 type MobileVscodeExtra = {
   MOBILE_VSCODE_SERVER_URL?: unknown;
   LOCAL_IP?: unknown;
 };
-
-function normalizeServerOrigin(rawValue: string): string {
-  const value = rawValue.trim();
-
-  if (value.includes('YOUR_COMPUTER_IP_HERE')) {
-    throw new Error('Replace YOUR_COMPUTER_IP_HERE in the MobileVSCode server URL.');
-  }
-
-  const url = new URL(value);
-
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error('MobileVSCode server URL must use http:// or https://.');
-  }
-
-  if (url.username || url.password || url.search || url.hash) {
-    throw new Error('MobileVSCode server URL must be a plain origin without credentials, query, or fragment.');
-  }
-
-  if (url.pathname !== '/' && url.pathname !== '') {
-    throw new Error('MobileVSCode server URL must not include /graphql, /yjs, or another path.');
-  }
-
-  return `${url.protocol}//${url.host}`;
-}
 
 const extra = (Constants.expoConfig?.extra ?? {}) as MobileVscodeExtra;
 const configuredUrl =

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -1,70 +1,66 @@
-import React, { useEffect, useState } from 'react';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { Ionicons } from '@expo/vector-icons';
+import React, { useEffect } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import AuthScreen from '../screens/AuthScreen';
+import WorkspaceScreen from '../screens/WorkspaceScreen';
+import { useAuthStore } from '../state/authStore';
+import MainTabNavigator from './MainTabNavigator';
 
-// Import screens
-import ExplorerScreen from '../screens/Explorer';
-import EditorScreen from '../screens/Editor';
-import SearchScreen from '../screens/Search';
-import GitScreen from '../screens/Git';
-import ExtensionsScreen from '../screens/Extensions';
-import DebugScreen from '../screens/Debug';
+export type RootStackParamList = {
+  Auth: undefined;
+  WorkspaceList: undefined;
+  MainApp: { workspaceUri: string; workspaceName: string };
+};
 
-const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function AppNavigator() {
-  // (Optional) state or effect for handling navigation readiness, auth, etc.
-  const [isReady, setReady] = useState(false);
+  const token = useAuthStore(state => state.token);
+  const isHydrated = useAuthStore(state => state.isHydrated);
+  const loadToken = useAuthStore(state => state.loadToken);
 
   useEffect(() => {
-    // Any startup logic, e.g., check auth, then:
-    setReady(true);
-  }, []);
+    void loadToken();
+  }, [loadToken]);
 
-  if (!isReady) {
-    // Could return a loading indicator
-    return null;
+  if (!isHydrated) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
   }
 
   return (
-    <Tab.Navigator
-      initialRouteName="Explorer"
-      screenOptions={({ route }) => ({
-        headerShown: false,
-        tabBarIcon: ({ color, size }) => {
-          let iconName;
-          switch (route.name) {
-            case 'Explorer':
-              iconName = 'folder';
-              break;
-            case 'Editor':
-              iconName = 'code-slash';
-              break;
-            case 'Search':
-              iconName = 'search';
-              break;
-            case 'Git':
-              iconName = 'git-branch';
-              break;
-            case 'Extensions':
-              iconName = 'extensions'; // hypothetical icon name
-              break;
-            case 'Debug':
-              iconName = 'bug';
-              break;
-            default:
-              iconName = 'ellipse';
-          }
-          return <Ionicons name={iconName as any} size={size} color={color} />;
-        }
-      })}
-    >
-      <Tab.Screen name="Explorer" component={ExplorerScreen} />
-      <Tab.Screen name="Editor" component={EditorScreen as React.ComponentType<any>} />
-      <Tab.Screen name="Search" component={SearchScreen as React.ComponentType<any>} />
-      <Tab.Screen name="Git" component={GitScreen as React.ComponentType<any>} />
-      <Tab.Screen name="Extensions" component={ExtensionsScreen} />
-      <Tab.Screen name="Debug" component={DebugScreen as React.ComponentType<any>} />
-    </Tab.Navigator>
+    <Stack.Navigator>
+      {token ? (
+        <>
+          <Stack.Screen
+            name="WorkspaceList"
+            component={WorkspaceScreen}
+            options={{ title: 'Workspaces' }}
+          />
+          <Stack.Screen
+            name="MainApp"
+            component={MainTabNavigator}
+            options={{ headerShown: false }}
+          />
+        </>
+      ) : (
+        <Stack.Screen
+          name="Auth"
+          component={AuthScreen}
+          options={{ title: 'Pair Device' }}
+        />
+      )}
+    </Stack.Navigator>
   );
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/src/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator.tsx
@@ -1,45 +1,68 @@
 import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Ionicons } from '@expo/vector-icons';
+import ExplorerScreen from '../screens/Explorer';
+import SearchScreen from '../screens/Search';
+import GitScreen from '../screens/Git';
+import ExtensionsScreen from '../screens/Extensions';
+import DebugScreen from '../screens/Debug';
+import type { RootStackParamList } from './AppNavigator';
 
-import Explorer from '../screens/Explorer';
-import Git from '../screens/Git';
-import Extensions from '../screens/Extensions';
-import Search from '../screens/Search';
-import Debug from '../screens/Debug';
+type MainTabParamList = {
+  Explorer: { workspaceUri: string; workspaceName: string };
+  Search: { workspaceUri: string };
+  Git: { workspaceUri: string };
+  Extensions: undefined;
+  Debug: { workspaceUri: string };
+};
 
-const Tab = createBottomTabNavigator();
+type Props = NativeStackScreenProps<RootStackParamList, 'MainApp'>;
 
-const iconMap: Record<string, string> = {
-  Explorer: 'file-tree',
-  Search: 'magnify',
-  Git: 'source-branch',
-  Extensions: 'puzzle',
+const Tab = createBottomTabNavigator<MainTabParamList>();
+
+const icons: Record<keyof MainTabParamList, React.ComponentProps<typeof Ionicons>['name']> = {
+  Explorer: 'folder',
+  Search: 'search',
+  Git: 'git-branch',
+  Extensions: 'extension-puzzle',
   Debug: 'bug',
 };
 
-type MainTabNavigatorProps = { route: { params?: { workspaceUri?: string } } };
+export default function MainTabNavigator({ route }: Props) {
+  const { workspaceUri, workspaceName } = route.params;
 
-export default function MainTabNavigator({ route }: MainTabNavigatorProps) {
-  const { workspaceUri } = route.params || {};
   return (
     <Tab.Navigator
-      screenOptions={({ route }) => ({
-        tabBarIcon: ({ color, size }) => (
-          <Icon
-            name={(iconMap[route.name as keyof typeof iconMap] ?? 'file') as keyof typeof Icon.glyphMap}
-            size={size}
-            color={color}
-          />
-        ),
+      initialRouteName="Explorer"
+      screenOptions={({ route: tabRoute }) => ({
         headerShown: false,
+        tabBarIcon: ({ color, size }) => (
+          <Ionicons name={icons[tabRoute.name]} size={size} color={color} />
+        ),
       })}
     >
-      <Tab.Screen name="Explorer" component={Explorer as React.ComponentType<any>} initialParams={{ workspaceUri }} />
-      <Tab.Screen name="Search" component={Search as React.ComponentType<any>} initialParams={{ workspaceUri }} />
-      <Tab.Screen name="Git" component={Git as React.ComponentType<any>} initialParams={{ workspaceUri }} />
-      <Tab.Screen name="Extensions" component={Extensions as React.ComponentType<any>} initialParams={{ workspaceUri }} />
-      <Tab.Screen name="Debug" component={Debug as React.ComponentType<any>} initialParams={{ workspaceUri }} />
+      <Tab.Screen
+        name="Explorer"
+        component={ExplorerScreen as React.ComponentType<any>}
+        initialParams={{ workspaceUri, workspaceName }}
+      />
+      <Tab.Screen
+        name="Search"
+        component={SearchScreen as React.ComponentType<any>}
+        initialParams={{ workspaceUri }}
+      />
+      <Tab.Screen
+        name="Git"
+        component={GitScreen as React.ComponentType<any>}
+        initialParams={{ workspaceUri }}
+      />
+      <Tab.Screen name="Extensions" component={ExtensionsScreen} />
+      <Tab.Screen
+        name="Debug"
+        component={DebugScreen as React.ComponentType<any>}
+        initialParams={{ workspaceUri }}
+      />
     </Tab.Navigator>
   );
 }

--- a/apps/mobile/src/screens/AuthScreen.tsx
+++ b/apps/mobile/src/screens/AuthScreen.tsx
@@ -1,53 +1,82 @@
-import React, { useState } from "react";
-import { View, TextInput, Button, StyleSheet, Text } from "react-native";
-import { useMutation } from "@apollo/client";
-import { PairWithServerDocument } from "shared/types";
-import { useAuthStore } from "../state/authStore";
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useMutation } from '@apollo/client';
+import { PairWithServerDocument } from 'shared/types';
+import { SERVER_ORIGIN } from '../config';
+import { useAuthStore } from '../state/authStore';
 
 export default function AuthScreen() {
-  const [token, setTokenInput] = useState("");
-  const setToken = useAuthStore((s) => s.setToken);
-
-  // If PairWithServerDocument is ever undefined, Apollo will crash.
-  // This import path ("shared") ensures Metro resolves the built dist entry.
+  const [pairingToken, setPairingToken] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+  const setToken = useAuthStore(state => state.setToken);
   const [pair, { error, loading }] = useMutation(PairWithServerDocument);
 
+  const normalizedPairingToken = pairingToken.trim().toUpperCase();
+
   const handlePair = async () => {
+    if (!normalizedPairingToken || loading) return;
+
+    setLocalError(null);
+
     try {
-      const res = await pair({ variables: { pairingToken: token } });
-      const newToken = res.data?.pairWithServer;
-      if (newToken) setToken(newToken);
-    } catch (err) {
-      console.warn("Pairing failed", err);
+      const response = await pair({
+        variables: { pairingToken: normalizedPairingToken },
+      });
+      const clientToken = response.data?.pairWithServer;
+
+      if (!clientToken) {
+        throw new Error('The server did not return a session token.');
+      }
+
+      await setToken(clientToken);
+    } catch (pairingError) {
+      const message = pairingError instanceof Error ? pairingError.message : 'Pairing failed.';
+      setLocalError(message);
+      console.warn('Pairing failed.', pairingError);
     }
   };
 
   return (
     <View style={styles.container}>
       <Text style={styles.label}>Enter Pairing Token</Text>
+      <Text selectable style={styles.server} numberOfLines={1}>
+        Server: {SERVER_ORIGIN}
+      </Text>
       <TextInput
         style={styles.input}
-        value={token}
-        onChangeText={setTokenInput}
+        value={pairingToken}
+        onChangeText={value => {
+          setPairingToken(value);
+          setLocalError(null);
+        }}
         autoCapitalize="characters"
         autoCorrect={false}
-        placeholder="XXXX-XXXX"
+        placeholder="ABC123"
+        returnKeyType="go"
+        onSubmitEditing={() => void handlePair()}
       />
-      {error && <Text style={styles.error}>{error.message}</Text>}
-      <Button title={loading ? "Pairing..." : "Pair"} onPress={handlePair} />
+      {localError || error ? (
+        <Text selectable style={styles.error}>{localError ?? error?.message}</Text>
+      ) : null}
+      <Button
+        title={loading ? 'Pairing…' : 'Pair'}
+        onPress={() => void handlePair()}
+        disabled={loading || !normalizedPairingToken}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20, justifyContent: "center" },
+  container: { flex: 1, padding: 20, justifyContent: 'center' },
   label: { fontSize: 16, marginBottom: 8 },
+  server: { color: '#666', marginBottom: 12 },
   input: {
     borderWidth: 1,
-    borderColor: "#ccc",
+    borderColor: '#ccc',
     padding: 10,
     marginBottom: 16,
-    borderRadius: 8
+    borderRadius: 8,
   },
-  error: { color: "red", marginVertical: 8 }
+  error: { color: 'red', marginVertical: 8 },
 });

--- a/apps/mobile/src/screens/Search.tsx
+++ b/apps/mobile/src/screens/Search.tsx
@@ -23,7 +23,10 @@ export default function Search({ navigation, route }: SearchProps) {
 
   const handlePress = (item: SearchQuery['search'][0]) => {
     setEditorAction({ type: 'highlight-line', payload: { line: item.line } });
-    navigation.navigate('Explorer', { screen: 'Editor', params: { path: item.path } });
+    navigation.navigate('Explorer', {
+      screen: 'Editor',
+      params: { workspaceUri, path: item.path },
+    });
   };
 
   return (

--- a/apps/mobile/src/screens/WorkspaceScreen.tsx
+++ b/apps/mobile/src/screens/WorkspaceScreen.tsx
@@ -1,40 +1,72 @@
 import React from 'react';
-import { View, Text, Button, FlatList, ActivityIndicator, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+import {
+  ActivityIndicator,
+  Button,
+  FlatList,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useQuery } from '@apollo/client';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { ListWorkspacesDocument, ListWorkspacesQuery } from 'shared/types';
+import { client } from '../apolloClient';
+import type { RootStackParamList } from '../navigation/AppNavigator';
 import { useAuthStore } from '../state/authStore';
 
-type WorkspaceScreenProps = { navigation: { replace: (route: string, params: { workspaceUri: string; workspaceName: string }) => void } };
+type Props = NativeStackScreenProps<RootStackParamList, 'WorkspaceList'>;
 
-export default function WorkspaceScreen({ navigation }: WorkspaceScreenProps) {
-  const { data, loading, error, refetch } = useQuery<ListWorkspacesQuery>(ListWorkspacesDocument);
-  const setToken = useAuthStore(s => s.setToken);
+export default function WorkspaceScreen({ navigation }: Props) {
+  const { data, loading, error, refetch } = useQuery<ListWorkspacesQuery>(ListWorkspacesDocument, {
+    fetchPolicy: 'network-only',
+  });
+  const setToken = useAuthStore(state => state.setToken);
+
+  const handleLogout = async () => {
+    try {
+      await setToken(null);
+      await client.clearStore();
+    } catch (logoutError) {
+      console.warn('Unable to clear the MobileVSCode session.', logoutError);
+    }
+  };
 
   if (loading) return <ActivityIndicator style={styles.center} size="large" />;
-  if (error) return (
+
+  if (error) {
+    return (
       <View style={styles.center}>
-          <Text>Error loading workspaces: {error.message}</Text>
-          <Button title="Retry" onPress={() => refetch()} />
+        <Text selectable>Error loading workspaces: {error.message}</Text>
+        <Button title="Retry" onPress={() => void refetch()} />
+        <Button title="Pair Again" onPress={() => void handleLogout()} />
       </View>
-  );
+    );
+  }
 
   return (
     <SafeAreaView style={styles.container}>
       <FlatList
-        data={data?.listWorkspaces}
-        keyExtractor={(item) => item.uri}
+        contentContainerStyle={styles.content}
+        data={data?.listWorkspaces ?? []}
+        keyExtractor={item => item.uri}
         renderItem={({ item }) => (
-          <TouchableOpacity 
-            style={styles.item} 
-            onPress={() => navigation.replace('MainApp', { workspaceUri: item.uri, workspaceName: item.name })}
+          <TouchableOpacity
+            style={styles.item}
+            onPress={() => navigation.navigate('MainApp', {
+              workspaceUri: item.uri,
+              workspaceName: item.name,
+            })}
           >
             <Text style={styles.name}>{item.name}</Text>
-            <Text style={styles.uri} numberOfLines={1}>{item.uri}</Text>
+            <Text selectable style={styles.uri} numberOfLines={1}>{item.uri}</Text>
           </TouchableOpacity>
         )}
         ListHeaderComponent={<Text style={styles.title}>Select a Workspace</Text>}
-        ListFooterComponent={<Button title="Log Out" onPress={() => setToken(null)} />}
-        onRefresh={refetch}
+        ListEmptyComponent={<Text style={styles.empty}>No open VS Code workspaces were found.</Text>}
+        ListFooterComponent={<Button title="Log Out" onPress={() => void handleLogout()} />}
+        onRefresh={() => void refetch()}
         refreshing={loading}
       />
     </SafeAreaView>
@@ -44,7 +76,9 @@ export default function WorkspaceScreen({ navigation }: WorkspaceScreenProps) {
 const styles = StyleSheet.create({
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   container: { flex: 1, backgroundColor: '#f0f2f5' },
+  content: { flexGrow: 1 },
   title: { fontSize: 22, fontWeight: 'bold', padding: 16, backgroundColor: 'white' },
+  empty: { padding: 24, textAlign: 'center', color: 'gray' },
   item: {
     backgroundColor: 'white',
     paddingVertical: 16,

--- a/apps/mobile/src/state/authStore.ts
+++ b/apps/mobile/src/state/authStore.ts
@@ -1,27 +1,44 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { deleteItemAsync, getItemAsync, setItemAsync } from '../../modules/mobile-vscode-secure-store';
 import { create } from 'zustand';
-import { createJSONStorage, persist } from 'zustand/middleware';
+
+const TOKEN_KEY = 'mobile-vscode.auth-token';
 
 interface AuthState {
   token: string | null;
-  setToken: (t: string | null) => void;
+  isHydrated: boolean;
+  setToken: (token: string | null) => Promise<void>;
   loadToken: () => Promise<void>;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      token: null,
-      setToken: (t) => set({ token: t }),
-      loadToken: async () => {
-        const stored = await AsyncStorage.getItem('token');
-        if (stored) set({ token: stored });
-      },
-    }),
-    {
-      name: 'auth-storage',
-      storage: createJSONStorage(() => AsyncStorage),
-      partialize: state => ({ token: state.token }),
+export const useAuthStore = create<AuthState>((set, get) => ({
+  token: null,
+  isHydrated: false,
+
+  setToken: async token => {
+    if (token) {
+      await setItemAsync(TOKEN_KEY, token);
+      set({ token, isHydrated: true });
+      return;
     }
-  )
-);
+
+    try {
+      await deleteItemAsync(TOKEN_KEY);
+    } finally {
+      set({ token: null, isHydrated: true });
+    }
+  },
+
+  loadToken: async () => {
+    if (get().isHydrated) return;
+
+    try {
+      const token = await getItemAsync(TOKEN_KEY);
+      set({ token });
+    } catch (error) {
+      console.warn('Unable to load the MobileVSCode session token.', error);
+      set({ token: null });
+    } finally {
+      set({ isHydrated: true });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary

- restore the Pairing → Workspace → workspace-scoped tabs flow
- fix `PairWithServer` middleware matching and add regression coverage
- derive GraphQL, subscription, and Y.js endpoints from one validated server origin
- add iOS local-network/ATS configuration and Android cleartext configuration
- persist development and release sessions with an app-local iOS Keychain / Android Keystore module
- preserve Expo Go compatibility with a session-only fallback when the native module is absent

## Root cause

The mobile client mounted its tab navigator before authentication and workspace selection, did not propagate workspace context to every tab, and always used HTTPS/WSS even though the extension normally serves HTTP/WS. The pairing middleware also matched the wrong GraphQL operation name.

## Developer impact

The app now starts in a deterministic authentication flow, opens only after a workspace has been selected, and uses a single server-origin setting across iOS, Android, physical devices, and simulators. Native development and release builds retain the pairing token in device-bound secure storage; Expo Go remains usable but requires re-pairing after an app restart.

## Validation

- clean patch application and whitespace checks
- TypeScript/TSX syntax validation across changed sources
- executable smoke tests for pairing, endpoint derivation, app config, Android networking configuration, and token hydration
- Swift parser validation
- Kotlin module compilation against Android and Expo API stubs

## Native verification still required

GitHub/EAS CI should run the repository dependency install, code generation, TypeScript/lint/tests, Android build, and iOS build. The authoring environment did not contain Xcode or an Android emulator, so it does not claim a completed device or simulator launch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the Pairing → Workspace → tabs flow and made the app reliably connect to the local VS Code server on iOS and Android. Standardized endpoints, fixed pairing middleware, and added secure, device‑bound session storage with an Expo Go/web session‑only fallback.

- **Bug Fixes**
  - Corrected pairing operation handling (`PAIRING_OPERATION_NAME`); added backend tests for pairing, passthrough, and invalid tokens.
  - Deterministic bootstrap: hydrate secure session → authenticate → select workspace → mount tabs; workspace context flows to all tabs (e.g., Search → Explorer opens with `workspaceUri`).
  - Unified GraphQL/subscription/Y.js endpoints from one validated server origin; iOS Keychain updates now replace only value data.
  - Secure storage now logs recovery failures and invalidates unusable entries to prevent stuck sessions.

- **New Features**
  - Local networking: iOS ATS allowances and Android cleartext via `./plugins/with-mobile-vscode-networking`, driven by the server origin.
  - Device‑bound session storage (iOS Keychain / Android Keystore); Expo Go and web stay session‑only with a clear warning.
  - Shared server URL validation (`normalizeServerOrigin`) in Expo config and at runtime, with loopback warnings for physical devices.
  - Auth screen shows the server origin with clearer pairing errors; updated `.env` examples for `EXPO_PUBLIC_MOBILE_VSCODE_SERVER_URL` with `LOCAL_IP` fallback.

<sup>Written for commit bd589858555614ce9608ceb5badd41e8e8c216c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ales27pm/mobile-vscode-project/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace selection and workspace-aware navigation across Explorer, Search, Git, and Debug.
  * Added secure session-token storage on mobile platforms.
  * Added clearer pairing status, validation, error messages, and server address visibility.
  * Added configurable local server connections with HTTP/HTTPS support.

* **Bug Fixes**
  * Improved workspace loading, refreshing, empty states, logout, and “Pair Again” recovery.
  * Corrected pairing operation handling and invalid-token responses.

* **Tests**
  * Added coverage for successful pairing, non-pairing requests, and invalid tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->